### PR TITLE
oops (#224)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,103 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '27 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: javascript-typescript
+          build-mode: none
+        - language: rust
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/public/data/craftables/recipes.json
+++ b/public/data/craftables/recipes.json
@@ -86,5 +86,165 @@
     "cooldownSeconds": 1800,
     "requiresLevel": 5,
     "maxPerDay": 1
+  },
+  {
+    "id": "assemble_leather_armor",
+    "name": "Assemble Leather Armor",
+    "type": "armor_assembly",
+    "description": "Combine all six Leather Armor pieces into a full set.",
+    "inputs": [
+      {
+        "id": "leather_armor_head",
+        "amount": 1
+      },
+      {
+        "id": "leather_armor_chest",
+        "amount": 1
+      },
+      {
+        "id": "leather_armor_arm_l",
+        "amount": 1
+      },
+      {
+        "id": "leather_armor_arm_r",
+        "amount": 1
+      },
+      {
+        "id": "leather_armor_leg_l",
+        "amount": 1
+      },
+      {
+        "id": "leather_armor_leg_r",
+        "amount": 1
+      }
+    ],
+    "output": {
+      "itemId": "leather_armor_full",
+      "qty": 1
+    },
+    "tokenCost": 0,
+    "cooldownSeconds": 0,
+    "requiresLevel": 5,
+    "maxPerDay": 5
+  },
+  {
+    "id": "assemble_combat_armor",
+    "name": "Assemble Combat Armor",
+    "type": "armor_assembly",
+    "description": "Combine all six Combat Armor pieces into a full military set.",
+    "inputs": [
+      {
+        "id": "combat_armor_head",
+        "amount": 1
+      },
+      {
+        "id": "combat_armor_chest",
+        "amount": 1
+      },
+      {
+        "id": "combat_armor_arm_l",
+        "amount": 1
+      },
+      {
+        "id": "combat_armor_arm_r",
+        "amount": 1
+      },
+      {
+        "id": "combat_armor_leg_l",
+        "amount": 1
+      },
+      {
+        "id": "combat_armor_leg_r",
+        "amount": 1
+      }
+    ],
+    "output": {
+      "itemId": "combat_armor_full",
+      "qty": 1
+    },
+    "tokenCost": 0,
+    "cooldownSeconds": 0,
+    "requiresLevel": 15,
+    "maxPerDay": 2
+  },
+  {
+    "id": "assemble_t45_power_armor",
+    "name": "Assemble T-45 Power Armor",
+    "type": "armor_assembly",
+    "description": "Combine all six T-45 Power Armor pieces at the Armor Workbench.",
+    "inputs": [
+      {
+        "id": "t45_pa_head",
+        "amount": 1
+      },
+      {
+        "id": "t45_pa_chest",
+        "amount": 1
+      },
+      {
+        "id": "t45_pa_arm_l",
+        "amount": 1
+      },
+      {
+        "id": "t45_pa_arm_r",
+        "amount": 1
+      },
+      {
+        "id": "t45_pa_leg_l",
+        "amount": 1
+      },
+      {
+        "id": "t45_pa_leg_r",
+        "amount": 1
+      }
+    ],
+    "output": {
+      "itemId": "t45_power_armor_full",
+      "qty": 1
+    },
+    "tokenCost": 0,
+    "cooldownSeconds": 0,
+    "requiresLevel": 25,
+    "maxPerDay": 1
+  },
+  {
+    "id": "assemble_t51b_power_armor",
+    "name": "Assemble T-51b Power Armor",
+    "type": "armor_assembly",
+    "description": "Collect all six T-51b Power Armor pieces and forge a legend at the Armor Workbench.",
+    "inputs": [
+      {
+        "id": "t51b_pa_head",
+        "amount": 1
+      },
+      {
+        "id": "t51b_pa_chest",
+        "amount": 1
+      },
+      {
+        "id": "t51b_pa_arm_l",
+        "amount": 1
+      },
+      {
+        "id": "t51b_pa_arm_r",
+        "amount": 1
+      },
+      {
+        "id": "t51b_pa_leg_l",
+        "amount": 1
+      },
+      {
+        "id": "t51b_pa_leg_r",
+        "amount": 1
+      }
+    ],
+    "output": {
+      "itemId": "t51b_power_armor_full",
+      "qty": 1
+    },
+    "tokenCost": 0,
+    "cooldownSeconds": 0,
+    "requiresLevel": 30,
+    "maxPerDay": 1
   }
 ]

--- a/public/data/items/armor_sets.json
+++ b/public/data/items/armor_sets.json
@@ -1,0 +1,90 @@
+{
+  "leather_armor": {
+    "name": "Leather Armor",
+    "tier": "uncommon",
+    "description": "A full set of hand-stitched leather armor. Wasteland standard issue.",
+    "pieces": ["head", "chest", "arm_l", "arm_r", "leg_l", "leg_r"],
+    "pieceIds": {
+      "head":  "leather_armor_head",
+      "chest": "leather_armor_chest",
+      "arm_l": "leather_armor_arm_l",
+      "arm_r": "leather_armor_arm_r",
+      "leg_l": "leather_armor_leg_l",
+      "leg_r": "leather_armor_leg_r"
+    },
+    "assembledId": "leather_armor_full",
+    "assembleRecipeId": "assemble_leather_armor",
+    "requiresLevel": 5,
+    "fullSetBonus": {
+      "ballisticResist": 8,
+      "radResist": 2,
+      "capsValue": 210
+    }
+  },
+  "combat_armor": {
+    "name": "Combat Armor",
+    "tier": "rare",
+    "description": "Full military-grade combat armor. Covers head-to-toe with ballistic ceramic.",
+    "pieces": ["head", "chest", "arm_l", "arm_r", "leg_l", "leg_r"],
+    "pieceIds": {
+      "head":  "combat_armor_head",
+      "chest": "combat_armor_chest",
+      "arm_l": "combat_armor_arm_l",
+      "arm_r": "combat_armor_arm_r",
+      "leg_l": "combat_armor_leg_l",
+      "leg_r": "combat_armor_leg_r"
+    },
+    "assembledId": "combat_armor_full",
+    "assembleRecipeId": "assemble_combat_armor",
+    "requiresLevel": 15,
+    "fullSetBonus": {
+      "ballisticResist": 22,
+      "radResist": 5,
+      "capsValue": 600
+    }
+  },
+  "t45_power_armor": {
+    "name": "T-45 Power Armor",
+    "tier": "epic",
+    "description": "Early pre-war power armor. A full set grants immense ballistic and radiation protection.",
+    "pieces": ["head", "chest", "arm_l", "arm_r", "leg_l", "leg_r"],
+    "pieceIds": {
+      "head":  "t45_pa_head",
+      "chest": "t45_pa_chest",
+      "arm_l": "t45_pa_arm_l",
+      "arm_r": "t45_pa_arm_r",
+      "leg_l": "t45_pa_leg_l",
+      "leg_r": "t45_pa_leg_r"
+    },
+    "assembledId": "t45_power_armor_full",
+    "assembleRecipeId": "assemble_t45_power_armor",
+    "requiresLevel": 25,
+    "fullSetBonus": {
+      "ballisticResist": 55,
+      "radResist": 30,
+      "capsValue": 2500
+    }
+  },
+  "t51b_power_armor": {
+    "name": "T-51b Power Armor",
+    "tier": "legendary",
+    "description": "The pinnacle of pre-war power armor technology. Assembling a full set is the dream of every wastelander.",
+    "pieces": ["head", "chest", "arm_l", "arm_r", "leg_l", "leg_r"],
+    "pieceIds": {
+      "head":  "t51b_pa_head",
+      "chest": "t51b_pa_chest",
+      "arm_l": "t51b_pa_arm_l",
+      "arm_r": "t51b_pa_arm_r",
+      "leg_l": "t51b_pa_leg_l",
+      "leg_r": "t51b_pa_leg_r"
+    },
+    "assembledId": "t51b_power_armor_full",
+    "assembleRecipeId": "assemble_t51b_power_armor",
+    "requiresLevel": 30,
+    "fullSetBonus": {
+      "ballisticResist": 90,
+      "radResist": 60,
+      "capsValue": 7500
+    }
+  }
+}

--- a/public/data/items/loot_tables.json
+++ b/public/data/items/loot_tables.json
@@ -1,486 +1,1099 @@
 {
-  "version": "1.0.0",
-  "description": "Comprehensive Atomic Fizz Caps loot drop tables — tiered, faction-specific, timeline-specific, NFT-eligible",
+  "version": "2.0.0",
+  "description": "Atomic Fizz Caps loot drop tables v2 \u2014 rebalanced weights, full CAPS economy, Fallout-authentic items, crypto-layer NFTs",
   "meta": {
-    "nft_drop_base_chance": 0.02,
-    "legendary_base_chance": 0.05,
-    "epic_base_chance": 0.12,
-    "rare_base_chance": 0.28,
-    "uncommon_base_chance": 0.35,
-    "common_base_chance": 0.18,
-    "level_scaling_factor": 0.002
+    "nft_drop_base_chance": 0.01,
+    "legendary_base_chance": 0.025,
+    "epic_base_chance": 0.06,
+    "rare_base_chance": 0.15,
+    "uncommon_base_chance": 0.3,
+    "common_base_chance": 0.45,
+    "level_scaling_factor": 0.001
   },
   "tiers": {
     "common": [
       {
-        "id": "scrap_metal", "name": "Scrap Metal", "type": "junk", "rarity": "common",
-        "value_caps": 4, "value_fizz": 0, "nft_eligible": false,
-        "description": "Rusted chunks of pre-war steel. Smells like rain.",
-        "weight": 1.5
+        "id": "scrap_metal",
+        "name": "Scrap Metal",
+        "type": "junk",
+        "weight": 3.0,
+        "capsValue": 2,
+        "tradeable": true,
+        "description": "Twisted hunks of pre-war steel. Useful for repairs."
       },
       {
-        "id": "cloth_rags", "name": "Cloth Rags", "type": "junk", "rarity": "common",
-        "value_caps": 2, "value_fizz": 0, "nft_eligible": false,
-        "description": "Fragments of pre-war fabric. Still useful for patching and padding.",
-        "weight": 0.2
+        "id": "cloth_rags",
+        "name": "Cloth Rags",
+        "type": "junk",
+        "weight": 2.0,
+        "capsValue": 1,
+        "tradeable": true,
+        "description": "Tattered fabric scraps. Every wastelander needs some."
       },
       {
-        "id": "dirty_water", "name": "Dirty Water", "type": "consumable", "rarity": "common",
-        "value_caps": 5, "value_fizz": 0, "nft_eligible": false,
-        "description": "Contaminated water. Hydrating and mildly irradiating.",
-        "heal": 5, "rads": 15, "weight": 1.0
+        "id": "dirty_water",
+        "name": "Dirty Water",
+        "type": "consumable",
+        "weight": 2.5,
+        "capsValue": 3,
+        "tradeable": true,
+        "description": "Irradiated water from a cracked pipe. Drink at your own risk. +1 RAD."
       },
       {
-        "id": "ammo_38", "name": ".38 Rounds", "type": "ammo", "rarity": "common",
-        "value_caps": 2, "value_fizz": 0, "nft_eligible": false,
-        "description": "Common pistol caliber. Found everywhere. Means nowhere is safe.",
-        "quantity_range": [5, 20], "weight": 0.01
+        "id": "prewar_food_can",
+        "name": "Pre-War Food Can",
+        "type": "consumable",
+        "weight": 2.5,
+        "capsValue": 5,
+        "tradeable": true,
+        "description": "200-year-old canned mystery meat. Still edible. Somehow."
       },
       {
-        "id": "bobby_pin", "name": "Bobby Pin", "type": "tool", "rarity": "common",
-        "value_caps": 1, "value_fizz": 0, "nft_eligible": false,
-        "description": "Invaluable for locks. Terrible as a hairpin.",
-        "quantity_range": [1, 8], "weight": 0.01
+        "id": "duct_tape",
+        "name": "Duct Tape",
+        "type": "junk",
+        "weight": 2.0,
+        "capsValue": 3,
+        "tradeable": true,
+        "description": "The glue holding the wasteland together. Literally."
       },
       {
-        "id": "pre_war_food_can", "name": "Pre-War Food Can", "type": "consumable", "rarity": "common",
-        "value_caps": 15, "value_fizz": 0, "nft_eligible": false,
-        "description": "Preserved before the bombs. The taste has changed, but it's technically food.",
-        "heal": 12, "rads": 5, "weight": 0.5
+        "id": "wood_planks",
+        "name": "Wood Planks",
+        "type": "junk",
+        "weight": 2.0,
+        "capsValue": 2,
+        "tradeable": true,
+        "description": "Rough-cut lumber. Good for building and burning."
       },
       {
-        "id": "duct_tape", "name": "Duct Tape", "type": "junk", "rarity": "common",
-        "value_caps": 8, "value_fizz": 0, "nft_eligible": false,
-        "description": "Pre-war adhesive tape. Still the most useful object in the wasteland.",
-        "weight": 0.1, "crafting_component": true
+        "id": "glass_bottle",
+        "name": "Glass Bottle",
+        "type": "junk",
+        "weight": 1.5,
+        "capsValue": 1,
+        "tradeable": true,
+        "description": "Empty and slightly irradiated. Fill it with something."
       },
       {
-        "id": "wood_planks", "name": "Wood Planks", "type": "junk", "rarity": "common",
-        "value_caps": 3, "value_fizz": 0, "nft_eligible": false,
-        "description": "Rough-cut planks. Useful for building and burning.",
-        "quantity_range": [1, 5], "weight": 2.0
+        "id": "bobby_pin",
+        "name": "Bobby Pin",
+        "type": "tool",
+        "weight": 2.0,
+        "capsValue": 3,
+        "tradeable": true,
+        "description": "The wastelander's universal key. Breaks often."
       },
       {
-        "id": "ammo_9mm", "name": "9mm Rounds", "type": "ammo", "rarity": "common",
-        "value_caps": 2, "value_fizz": 0, "nft_eligible": false,
-        "description": "Standard pistol ammunition. Pre-war and still plentiful.",
-        "quantity_range": [8, 24], "weight": 0.01
+        "id": "tin_can",
+        "name": "Tin Can",
+        "type": "junk",
+        "weight": 2.0,
+        "capsValue": 1,
+        "tradeable": true,
+        "description": "A bent tin can. Useful for tripwire alarms or stews."
       },
       {
-        "id": "glass_bottle", "name": "Glass Bottle", "type": "junk", "rarity": "common",
-        "value_caps": 3, "value_fizz": 0, "nft_eligible": false,
-        "description": "Pre-war glass. Useful for molotovs, storage, and desperate scrap.",
-        "weight": 0.2
+        "id": "cigarette_carton",
+        "name": "Cigarette Carton",
+        "type": "junk",
+        "weight": 1.5,
+        "capsValue": 8,
+        "tradeable": true,
+        "description": "Smokes are currency in most settlements."
+      },
+      {
+        "id": "wonderglue",
+        "name": "Wonderglue",
+        "type": "junk",
+        "weight": 1.5,
+        "capsValue": 5,
+        "tradeable": true,
+        "description": "Industrial adhesive. Fixes weapons, armor, and mistakes."
+      },
+      {
+        "id": "bottle_caps_loose",
+        "name": "Bottle Caps (Loose)",
+        "type": "currency",
+        "weight": 2.5,
+        "capsValue": 15,
+        "tradeable": true,
+        "capsMin": 5,
+        "capsMax": 25,
+        "description": "A handful of bent bottle caps \u2014 the currency of the wasteland."
       }
     ],
     "uncommon": [
       {
-        "id": "stimpak", "name": "Stimpak", "type": "consumable", "rarity": "uncommon",
-        "value_caps": 75, "value_fizz": 6, "nft_eligible": false,
-        "description": "Auto-injecting medical solution. The wasteland's primary healthcare plan.",
-        "heal": 30, "weight": 0.1
+        "id": "stimpak",
+        "name": "Stimpak",
+        "type": "consumable",
+        "weight": 2.0,
+        "capsValue": 25,
+        "tradeable": true,
+        "description": "Auto-inject healing compound. Standard wasteland medicine."
       },
       {
-        "id": "rad_away", "name": "RadAway", "type": "consumable", "rarity": "uncommon",
-        "value_caps": 55, "value_fizz": 4, "nft_eligible": false,
-        "description": "Intravenous radiation treatment. Tastes like regret.",
-        "rad_reduction": 80, "weight": 0.1
+        "id": "radaway",
+        "name": "RadAway",
+        "type": "consumable",
+        "weight": 2.0,
+        "capsValue": 20,
+        "tradeable": true,
+        "description": "IV drip that flushes radiation. Tastes like regret."
       },
       {
-        "id": "ammo_556", "name": "5.56mm Rounds", "type": "ammo", "rarity": "uncommon",
-        "value_caps": 6, "value_fizz": 0, "nft_eligible": false,
-        "description": "Intermediate rifle caliber. The NCR's favorite.",
-        "quantity_range": [15, 40], "weight": 0.01
+        "id": "rad_x",
+        "name": "Rad-X",
+        "type": "consumable",
+        "weight": 1.5,
+        "capsValue": 15,
+        "tradeable": true,
+        "description": "Prophylactic radiation blocker. Pop before entering a hot zone."
       },
       {
-        "id": "pipe_pistol", "name": "Pipe Pistol", "type": "weapon", "rarity": "uncommon",
-        "value_caps": 95, "value_fizz": 7, "nft_eligible": false,
-        "description": "Crudely assembled but functional. Fires when it fires.",
-        "damage": 18, "ammo_type": "ammo_38", "weight": 2.1
+        "id": "mentats",
+        "name": "Mentats",
+        "type": "consumable",
+        "weight": 1.5,
+        "capsValue": 20,
+        "tradeable": true,
+        "description": "Brain-enhancing chems. +INT for a limited time."
       },
       {
-        "id": "leather_armor_piece", "name": "Leather Armor Piece", "type": "armor", "rarity": "uncommon",
-        "value_caps": 120, "value_fizz": 9, "nft_eligible": false,
-        "description": "Cured hide stitched over foam backing. Better than nothing by exactly enough.",
-        "armor_rating": 12, "slot": "chest", "weight": 5.0
+        "id": "buffout",
+        "name": "Buffout",
+        "type": "consumable",
+        "weight": 1.5,
+        "capsValue": 20,
+        "tradeable": true,
+        "description": "Muscle-boosting chem. +STR, +END. Highly addictive."
       },
       {
-        "id": "fusion_cell", "name": "Fusion Cell", "type": "ammo", "rarity": "uncommon",
-        "value_caps": 14, "value_fizz": 1, "nft_eligible": false,
-        "description": "Energy weapon ammunition. Compact and powerful.",
-        "quantity_range": [5, 20], "weight": 0.02
+        "id": "jet",
+        "name": "Jet",
+        "type": "consumable",
+        "weight": 1.5,
+        "capsValue": 18,
+        "tradeable": true,
+        "description": "Methamphetamine derivative. Slows perceived time. Very addictive."
       },
       {
-        "id": "mentats", "name": "Mentats", "type": "consumable", "rarity": "uncommon",
-        "value_caps": 100, "value_fizz": 8, "nft_eligible": false,
-        "description": "Cognitive enhancement chems. Pre-war pharmaceuticals at their finest.",
-        "int_bonus": 2, "per_bonus": 2, "duration_seconds": 300, "weight": 0.1
+        "id": "ammo_38_x20",
+        "name": ".38 Rounds (\u00d720)",
+        "type": "ammo",
+        "weight": 2.0,
+        "capsValue": 8,
+        "tradeable": true,
+        "description": "Standard .38 caliber rounds. Common in the wasteland."
       },
       {
-        "id": "jet", "name": "Jet", "type": "consumable", "rarity": "uncommon",
-        "value_caps": 150, "value_fizz": 12, "nft_eligible": false,
-        "description": "Brahmin dung-derived speed enhancement. Don't think too hard about the source.",
-        "ap_bonus": 30, "duration_seconds": 60, "addiction_chance": 0.2, "weight": 0.1
+        "id": "ammo_9mm_x20",
+        "name": "9mm Rounds (\u00d720)",
+        "type": "ammo",
+        "weight": 2.0,
+        "capsValue": 10,
+        "tradeable": true,
+        "description": "9mm pistol rounds. Widespread and reliable."
       },
       {
-        "id": "lockpick_kit", "name": "Lockpick Kit", "type": "tool", "rarity": "uncommon",
-        "value_caps": 85, "value_fizz": 6, "nft_eligible": false,
-        "description": "Professional-grade lock picking tools. Legitimate uses are rare.",
-        "durability": 20, "weight": 0.5
+        "id": "ammo_308_x10",
+        "name": ".308 Rounds (\u00d710)",
+        "type": "ammo",
+        "weight": 1.5,
+        "capsValue": 15,
+        "tradeable": true,
+        "description": "Rifle-caliber rounds. Good for hunting man and beast."
       },
       {
-        "id": "combat_knife", "name": "Combat Knife", "type": "weapon", "rarity": "uncommon",
-        "value_caps": 140, "value_fizz": 11, "nft_eligible": false,
-        "description": "Military-issue blade. Pre-war quality means it's still sharp.",
-        "damage": 22, "weight": 1.0
+        "id": "pipe_pistol",
+        "name": "Pipe Pistol",
+        "type": "weapon",
+        "weight": 2.0,
+        "capsValue": 40,
+        "tradeable": true,
+        "description": "A crude handmade sidearm. Unreliable, but it shoots."
       },
       {
-        "id": "buffout", "name": "Buffout", "type": "consumable", "rarity": "uncommon",
-        "value_caps": 120, "value_fizz": 9, "nft_eligible": false,
-        "description": "Strength and endurance enhancement. Pre-war athletes used this.",
-        "str_bonus": 2, "end_bonus": 2, "duration_seconds": 240, "addiction_chance": 0.1, "weight": 0.1
+        "id": "leather_armor_head",
+        "name": "Leather Armor Helmet",
+        "type": "armor",
+        "armorSet": "leather_armor",
+        "slot": "head",
+        "weight": 0.8,
+        "capsValue": 35,
+        "tradeable": true,
+        "description": "Padded leather headgear. Smells like the wasteland."
       },
       {
-        "id": "ammo_308", "name": ".308 Rounds", "type": "ammo", "rarity": "uncommon",
-        "value_caps": 8, "value_fizz": 1, "nft_eligible": false,
-        "description": "High-powered rifle ammunition. Preferred by snipers.",
-        "quantity_range": [10, 30], "weight": 0.01
+        "id": "leather_armor_chest",
+        "name": "Leather Armor Chest Piece",
+        "type": "armor",
+        "armorSet": "leather_armor",
+        "slot": "chest",
+        "weight": 0.8,
+        "capsValue": 35,
+        "tradeable": true,
+        "description": "Padded leather torso guard. Better than rags."
+      },
+      {
+        "id": "leather_armor_arm_l",
+        "name": "Leather Armor Left Arm",
+        "type": "armor",
+        "armorSet": "leather_armor",
+        "slot": "arm_l",
+        "weight": 0.6,
+        "capsValue": 28,
+        "tradeable": true,
+        "description": "Left arm bracer, hand-stitched leather."
+      },
+      {
+        "id": "leather_armor_arm_r",
+        "name": "Leather Armor Right Arm",
+        "type": "armor",
+        "armorSet": "leather_armor",
+        "slot": "arm_r",
+        "weight": 0.6,
+        "capsValue": 28,
+        "tradeable": true,
+        "description": "Right arm bracer, hand-stitched leather."
+      },
+      {
+        "id": "leather_armor_leg_l",
+        "name": "Leather Armor Left Leg",
+        "type": "armor",
+        "armorSet": "leather_armor",
+        "slot": "leg_l",
+        "weight": 0.7,
+        "capsValue": 28,
+        "tradeable": true,
+        "description": "Leather leg guard, left side. Keeps the radscorpion stingers at bay."
+      },
+      {
+        "id": "leather_armor_leg_r",
+        "name": "Leather Armor Right Leg",
+        "type": "armor",
+        "armorSet": "leather_armor",
+        "slot": "leg_r",
+        "weight": 0.7,
+        "capsValue": 28,
+        "tradeable": true,
+        "description": "Leather leg guard, right side. Worn but functional."
+      },
+      {
+        "id": "combat_knife",
+        "name": "Combat Knife",
+        "type": "weapon",
+        "weight": 1.5,
+        "capsValue": 35,
+        "tradeable": true,
+        "description": "Military-issue blade. Silent and deadly up close."
+      },
+      {
+        "id": "lockpick_kit",
+        "name": "Lockpick Kit",
+        "type": "tool",
+        "weight": 1.5,
+        "capsValue": 30,
+        "tradeable": true,
+        "description": "Tension wrench and picks. Opens what shouldn't be opened."
+      },
+      {
+        "id": "wasteland_medkit",
+        "name": "Wasteland Medkit",
+        "type": "medical",
+        "weight": 1.5,
+        "capsValue": 45,
+        "tradeable": true,
+        "description": "Bandages, antiseptic, and shrapnel tweezers. Field-assembled."
+      },
+      {
+        "id": "prewar_money",
+        "name": "Pre-War Money",
+        "type": "currency",
+        "weight": 1.5,
+        "capsValue": 12,
+        "tradeable": true,
+        "description": "Worthless paper dollars. Valued by collectors."
       }
     ],
     "rare": [
       {
-        "id": "laser_pistol", "name": "Laser Pistol", "type": "weapon", "rarity": "rare",
-        "value_caps": 850, "value_fizz": 68, "nft_eligible": false,
-        "description": "Institute-adjacent energy weapon. Precise, quiet, and very effective.",
-        "damage": 35, "ammo_type": "fusion_cell", "weight": 3.2
+        "id": "laser_pistol",
+        "name": "Laser Pistol",
+        "type": "weapon",
+        "weight": 2.0,
+        "capsValue": 150,
+        "tradeable": true,
+        "description": "Pre-war energy sidearm. Burns clean holes through enemies."
       },
       {
-        "id": "combat_armor_chest", "name": "Combat Armor (Chest)", "type": "armor", "rarity": "rare",
-        "value_caps": 1200, "value_fizz": 95, "nft_eligible": false,
-        "description": "Military-grade ballistic armor. Pre-war spec.",
-        "armor_rating": 35, "slot": "chest", "weight": 12.0
+        "id": "combat_armor_head",
+        "name": "Combat Armor Helmet",
+        "type": "armor",
+        "armorSet": "combat_armor",
+        "slot": "head",
+        "weight": 0.5,
+        "capsValue": 100,
+        "tradeable": true,
+        "description": "Military ballistic helmet. Rated for small arms."
       },
       {
-        "id": "ultra_stimpak", "name": "Ultra Stimpak", "type": "consumable", "rarity": "rare",
-        "value_caps": 400, "value_fizz": 32, "nft_eligible": false,
-        "description": "Military-grade field trauma injector. Rapid full-spectrum healing.",
-        "heal": 90, "limb_repair": true, "weight": 0.2
+        "id": "combat_armor_chest",
+        "name": "Combat Armor Chest Plate",
+        "type": "armor",
+        "armorSet": "combat_armor",
+        "slot": "chest",
+        "weight": 0.5,
+        "capsValue": 100,
+        "tradeable": true,
+        "description": "Military-grade torso protection. Favored by veteran mercs."
       },
       {
-        "id": "hunting_rifle_scoped", "name": "Scoped Hunting Rifle", "type": "weapon", "rarity": "rare",
-        "value_caps": 900, "value_fizz": 72, "nft_eligible": false,
-        "description": "Bolt-action precision rifle with pre-war optics. Still accurate at 600m.",
-        "damage": 52, "ammo_type": "ammo_308", "weight": 6.4
+        "id": "combat_armor_arm_l",
+        "name": "Combat Armor Left Arm",
+        "type": "armor",
+        "armorSet": "combat_armor",
+        "slot": "arm_l",
+        "weight": 0.4,
+        "capsValue": 80,
+        "tradeable": true,
+        "description": "Left arm combat plating with ceramic inserts."
       },
       {
-        "id": "psycho", "name": "Psycho", "type": "consumable", "rarity": "rare",
-        "value_caps": 180, "value_fizz": 14, "nft_eligible": false,
-        "description": "Combat stimulant with extreme side effects. The damage is real; so is the perception.",
-        "damage_bonus": 25, "damage_resistance": 10, "duration_seconds": 60, "addiction_chance": 0.3, "weight": 0.1
+        "id": "combat_armor_arm_r",
+        "name": "Combat Armor Right Arm",
+        "type": "armor",
+        "armorSet": "combat_armor",
+        "slot": "arm_r",
+        "weight": 0.4,
+        "capsValue": 80,
+        "tradeable": true,
+        "description": "Right arm combat plating. Slight laser scoring."
       },
       {
-        "id": "energy_weapon_mod_scope", "name": "Reflex Sight (Energy)", "type": "weapon_mod", "rarity": "rare",
-        "value_caps": 650, "value_fizz": 52, "nft_eligible": false,
-        "description": "Precision aiming reticle for energy weapons. Adds targeting precision.",
-        "compatible": ["laser_pistol", "plasma_pistol", "laser_rifle"], "weight": 0.3
+        "id": "combat_armor_leg_l",
+        "name": "Combat Armor Left Leg",
+        "type": "armor",
+        "armorSet": "combat_armor",
+        "slot": "leg_l",
+        "weight": 0.4,
+        "capsValue": 80,
+        "tradeable": true,
+        "description": "Left leg combat greave. Pre-war military surplus."
       },
       {
-        "id": "pre_war_circuit_board", "name": "Pre-War Circuit Board", "type": "component", "rarity": "rare",
-        "value_caps": 280, "value_fizz": 22, "nft_eligible": false,
-        "description": "Functional pre-war electronics. The foundation of advanced crafting.",
-        "crafting_component": true, "weight": 0.2
+        "id": "combat_armor_leg_r",
+        "name": "Combat Armor Right Leg",
+        "type": "armor",
+        "armorSet": "combat_armor",
+        "slot": "leg_r",
+        "weight": 0.4,
+        "capsValue": 80,
+        "tradeable": true,
+        "description": "Right leg combat greave. Still holds a polish."
       },
       {
-        "id": "rad_x", "name": "Rad-X", "type": "consumable", "rarity": "rare",
-        "value_caps": 220, "value_fizz": 17, "nft_eligible": false,
-        "description": "Radiation resistance pharmaceutical. Pre-exposure is the smart play.",
-        "rad_resist_bonus": 60, "duration_seconds": 600, "weight": 0.1
+        "id": "scoped_hunting_rifle",
+        "name": "Scoped Hunting Rifle",
+        "type": "weapon",
+        "weight": 2.0,
+        "capsValue": 175,
+        "tradeable": true,
+        "description": "Long-range precision rifle. Deadly in the right hands."
       },
       {
-        "id": "assault_rifle_military", "name": "Military Assault Rifle", "type": "weapon", "rarity": "rare",
-        "value_caps": 1400, "value_fizz": 112, "nft_eligible": false,
-        "description": "Full-auto military rifle. Pre-war military spec with the maintenance to match.",
-        "damage": 44, "ammo_type": "ammo_556", "weight": 7.2, "fire_mode": "auto"
+        "id": "military_assault_rifle",
+        "name": "Military Assault Rifle",
+        "type": "weapon",
+        "weight": 2.0,
+        "capsValue": 220,
+        "tradeable": true,
+        "description": "Full-auto .308 battle rifle. Pre-war military issue."
       },
       {
-        "id": "surgical_kit_advanced", "name": "Advanced Surgical Kit", "type": "medical", "rarity": "rare",
-        "value_caps": 800, "value_fizz": 64, "nft_eligible": false,
-        "description": "Full surgical toolkit in a hardened case. Followers of the Apocalypse standard.",
-        "surgery_capability": true, "uses": 5, "weight": 3.0
+        "id": "ultra_stimpak",
+        "name": "Ultra Stimpak",
+        "type": "consumable",
+        "weight": 1.5,
+        "capsValue": 75,
+        "tradeable": true,
+        "description": "High-potency healing compound. Fixes critical wounds fast."
       },
       {
-        "id": "stealth_boy", "name": "Stealth Boy", "type": "consumable", "rarity": "rare",
-        "value_caps": 600, "value_fizz": 48, "nft_eligible": false,
-        "description": "Personal stealth field generator. Render yourself temporarily invisible.",
-        "stealth_field_seconds": 30, "weight": 0.5
+        "id": "stealth_boy",
+        "name": "Stealth Boy",
+        "type": "consumable",
+        "weight": 1.0,
+        "capsValue": 120,
+        "tradeable": true,
+        "description": "Personal radar-stealth device. Limited charge."
       },
       {
-        "id": "plasma_grenade", "name": "Plasma Grenade", "type": "weapon", "rarity": "rare",
-        "value_caps": 350, "value_fizz": 28, "nft_eligible": false,
-        "description": "Plasma charge explosive. Messy. Effective.",
-        "damage": 120, "damage_type": "energy", "radius_m": 3, "weight": 0.5
+        "id": "plasma_grenade_x3",
+        "name": "Plasma Grenade (\u00d73)",
+        "type": "ammo",
+        "weight": 1.0,
+        "capsValue": 90,
+        "tradeable": true,
+        "description": "Three plasma grenades. Dissolves organic matter efficiently."
+      },
+      {
+        "id": "prewar_circuit_board",
+        "name": "Pre-War Circuit Board",
+        "type": "component",
+        "weight": 1.5,
+        "capsValue": 80,
+        "tradeable": true,
+        "description": "Intact pre-war electronics. Required for advanced crafting."
+      },
+      {
+        "id": "advanced_surgical_kit",
+        "name": "Advanced Surgical Kit",
+        "type": "medical",
+        "weight": 1.5,
+        "capsValue": 110,
+        "tradeable": true,
+        "description": "Sterile surgical tools. For when a Stimpak just won't cut it."
+      },
+      {
+        "id": "fusion_cell_x12",
+        "name": "Fusion Cell (\u00d712)",
+        "type": "ammo",
+        "weight": 2.0,
+        "capsValue": 60,
+        "tradeable": true,
+        "description": "Energy cell for laser weapons. Pre-war standard issue."
+      },
+      {
+        "id": "ammo_556_x30",
+        "name": "5.56mm Rounds (\u00d730)",
+        "type": "ammo",
+        "weight": 2.0,
+        "capsValue": 45,
+        "tradeable": true,
+        "description": "Assault rifle ammunition. Common in military caches."
+      },
+      {
+        "id": "psycho",
+        "name": "Psycho",
+        "type": "consumable",
+        "weight": 1.0,
+        "capsValue": 65,
+        "tradeable": true,
+        "description": "Rage-inducing combat chem. +DMG, +DR, very addictive."
+      },
+      {
+        "id": "caps_stash",
+        "name": "Caps Stash",
+        "type": "currency",
+        "weight": 2.0,
+        "capsValue": 100,
+        "tradeable": false,
+        "capsMin": 50,
+        "capsMax": 150,
+        "description": "A stash of bottle caps hidden by a wastelander who didn't come back."
+      },
+      {
+        "id": "reflex_sight",
+        "name": "Reflex Sight (Energy)",
+        "type": "weapon_mod",
+        "weight": 1.0,
+        "capsValue": 95,
+        "tradeable": true,
+        "description": "Holographic sight compatible with energy weapons."
+      },
+      {
+        "id": "milgrade_duct_tape",
+        "name": "Military-Grade Duct Tape",
+        "type": "junk",
+        "weight": 1.5,
+        "capsValue": 55,
+        "tradeable": true,
+        "description": "Industrial-spec adhesive. Far superior to civilian tape."
       }
     ],
     "epic": [
       {
-        "id": "plasma_rifle", "name": "Plasma Rifle", "type": "weapon", "rarity": "epic",
-        "value_caps": 4500, "value_fizz": 360, "nft_eligible": true,
-        "description": "Military-grade plasma projection weapon. Reduces targets to goo. Very tidy, actually.",
-        "damage": 95, "ammo_type": "plasma_cartridge", "weight": 8.5,
-        "progression_unlock": "perk_energy_weapons"
+        "id": "plasma_rifle",
+        "name": "Plasma Rifle",
+        "type": "weapon",
+        "weight": 2.0,
+        "capsValue": 500,
+        "tradeable": true,
+        "description": "Military energy rifle firing superheated plasma bolts. Melts everything."
       },
       {
-        "id": "t45_power_armor_helm", "name": "T-45 Power Armor Helmet", "type": "armor", "rarity": "epic",
-        "value_caps": 6000, "value_fizz": 480, "nft_eligible": true,
-        "description": "Pre-war powered armor helmet. Full HUD display, environmental sealing.",
-        "armor_rating": 65, "slot": "head", "power_armor": true, "weight": 12.0
+        "id": "t45_pa_head",
+        "name": "T-45 Power Armor Helmet",
+        "type": "armor",
+        "armorSet": "t45_power_armor",
+        "slot": "head",
+        "weight": 0.5,
+        "capsValue": 300,
+        "tradeable": true,
+        "description": "Early power armor helmet. Rad shielding and HUD display."
       },
       {
-        "id": "gauss_rifle", "name": "Gauss Rifle", "type": "weapon", "rarity": "epic",
-        "value_caps": 5500, "value_fizz": 440, "nft_eligible": true,
-        "description": "Magnetic accelerator sniper weapon. Hits harder than anything short of a mini-nuke.",
-        "damage": 140, "ammo_type": "ammo_2mm_ec", "weight": 9.1, "charge_required": true,
-        "progression_unlock": "quest_gauss_mastery"
+        "id": "t45_pa_chest",
+        "name": "T-45 Power Armor Torso",
+        "type": "armor",
+        "armorSet": "t45_power_armor",
+        "slot": "chest",
+        "weight": 0.5,
+        "capsValue": 300,
+        "tradeable": true,
+        "description": "T-45 torso frame, pre-war military issue."
       },
       {
-        "id": "ballistic_weave_schematic", "name": "Ballistic Weave Schematic", "type": "schematic", "rarity": "epic",
-        "value_caps": 3500, "value_fizz": 280, "nft_eligible": false,
-        "description": "Railroad-developed ballistic weave armor technology schematic.",
-        "crafting_unlock": "ballistic_weave_mod", "weight": 0.1,
-        "faction": "railroad",
-        "progression_unlock": "perk_ballistic_weave"
+        "id": "t45_pa_arm_l",
+        "name": "T-45 Power Armor Left Arm",
+        "type": "armor",
+        "armorSet": "t45_power_armor",
+        "slot": "arm_l",
+        "weight": 0.4,
+        "capsValue": 240,
+        "tradeable": true,
+        "description": "Left arm actuator assembly. Hydraulics intact."
       },
       {
-        "id": "fusion_core_military", "name": "Military Fusion Core", "type": "ammo", "rarity": "epic",
-        "value_caps": 2200, "value_fizz": 176, "nft_eligible": false,
-        "description": "Full-capacity military fusion core. Powers power armor and fusion generators.",
-        "power_armor_fuel": true, "capacity": 100, "weight": 1.0
+        "id": "t45_pa_arm_r",
+        "name": "T-45 Power Armor Right Arm",
+        "type": "armor",
+        "armorSet": "t45_power_armor",
+        "slot": "arm_r",
+        "weight": 0.4,
+        "capsValue": 240,
+        "tradeable": true,
+        "description": "Right arm actuator assembly. Grip servos functional."
       },
       {
-        "id": "x_cell", "name": "X-Cell", "type": "consumable", "rarity": "epic",
-        "value_caps": 1800, "value_fizz": 144, "nft_eligible": false,
-        "description": "Pre-war performance enhancement beyond anything legal. Every SPECIAL +1.",
-        "all_special_bonus": 1, "duration_seconds": 600, "addiction_chance": 0.5, "weight": 0.1,
-        "timeline": "fallout_new_vegas"
+        "id": "t45_pa_leg_l",
+        "name": "T-45 Power Armor Left Leg",
+        "type": "armor",
+        "armorSet": "t45_power_armor",
+        "slot": "leg_l",
+        "weight": 0.4,
+        "capsValue": 240,
+        "tradeable": true,
+        "description": "Left leg actuator. Minor dents from pre-war combat."
       },
       {
-        "id": "anti_materiel_rifle", "name": "Anti-Materiel Rifle", "type": "weapon", "rarity": "epic",
-        "value_caps": 7500, "value_fizz": 600, "nft_eligible": true,
-        "description": "Massive caliber precision rifle for eliminating vehicles and power armor.",
-        "damage": 200, "ammo_type": "ammo_50cal", "weight": 18.0, "armor_penetrate": 0.8,
-        "timeline": "fallout_new_vegas"
+        "id": "t45_pa_leg_r",
+        "name": "T-45 Power Armor Right Leg",
+        "type": "armor",
+        "armorSet": "t45_power_armor",
+        "slot": "leg_r",
+        "weight": 0.4,
+        "capsValue": 240,
+        "tradeable": true,
+        "description": "Right leg actuator. Servo needs minor calibration."
       },
       {
-        "id": "railroad_armor_legendary", "name": "Railroad Coat (Legendary)", "type": "armor", "rarity": "epic",
-        "value_caps": 5000, "value_fizz": 400, "nft_eligible": true,
-        "description": "Railroad agent's legendary armored coat. Built for surviving courier work.",
-        "armor_rating": 45, "slot": "chest", "stealth_bonus": 15, "weight": 6.0,
-        "faction": "railroad"
+        "id": "gauss_rifle",
+        "name": "Gauss Rifle",
+        "type": "weapon",
+        "weight": 2.0,
+        "capsValue": 650,
+        "tradeable": true,
+        "description": "Electromagnetic coilgun. Fires accelerated projectiles at devastating velocity."
+      },
+      {
+        "id": "anti_materiel_rifle",
+        "name": "Anti-Materiel Rifle",
+        "type": "weapon",
+        "weight": 1.5,
+        "capsValue": 750,
+        "tradeable": true,
+        "description": "Heavy .50 caliber rifle designed to destroy vehicles. And people."
+      },
+      {
+        "id": "railroad_coat",
+        "name": "Railroad Coat (Legendary)",
+        "type": "armor",
+        "weight": 1.5,
+        "capsValue": 450,
+        "tradeable": true,
+        "description": "Ballistic weave-lined duster. Railroad operative gear.",
+        "slot": "full",
+        "armorSet": null
+      },
+      {
+        "id": "ballistic_weave_schematic",
+        "name": "Ballistic Weave Schematic",
+        "type": "schematic",
+        "weight": 1.0,
+        "capsValue": 350,
+        "tradeable": true,
+        "description": "Technical blueprint for weaving ballistic fiber into clothing."
+      },
+      {
+        "id": "military_fusion_core",
+        "name": "Military Fusion Core",
+        "type": "ammo",
+        "weight": 2.0,
+        "capsValue": 200,
+        "tradeable": true,
+        "description": "High-capacity fusion core for power armor. Rare and valuable."
+      },
+      {
+        "id": "x_cell",
+        "name": "X-Cell",
+        "type": "consumable",
+        "weight": 1.0,
+        "capsValue": 180,
+        "tradeable": true,
+        "description": "Powerful all-stats chem. Extremely addictive. Black market only."
+      },
+      {
+        "id": "nuka_cola_quantum",
+        "name": "Nuka-Cola Quantum",
+        "type": "consumable",
+        "weight": 1.5,
+        "capsValue": 250,
+        "tradeable": true,
+        "description": "Glowing blue Nuka-Cola variant. Radioactive and delicious."
+      },
+      {
+        "id": "caps_voucher",
+        "name": "CAPS Voucher",
+        "type": "currency",
+        "weight": 1.5,
+        "capsValue": 350,
+        "tradeable": false,
+        "capsMin": 200,
+        "capsMax": 500,
+        "onChain": true,
+        "description": "An authenticated in-game CAPS voucher. Redeemable for real on-chain CAPS."
       }
     ],
     "legendary": [
       {
-        "id": "fatman_launcher", "name": "Fat Man", "type": "weapon", "rarity": "legendary",
-        "value_caps": 25000, "value_fizz": 2000, "nft_eligible": true,
-        "description": "Portable nuclear catapult. Pre-war military's most compact act of insanity.",
-        "damage": 800, "ammo_type": "mini_nuke", "weight": 30.0, "damage_type": "nuclear",
-        "nft_metadata": { "collection": "Vault-77 Legendary Arsenal", "rarity_rank": 12 }
+        "id": "fat_man",
+        "name": "Fat Man",
+        "type": "weapon",
+        "weight": 1.5,
+        "capsValue": 2500,
+        "tradeable": true,
+        "description": "Shoulder-mounted mini nuclear catapult. The wasteland's ultimate statement piece."
       },
       {
-        "id": "grognak_axe", "name": "Grognak's Axe", "type": "weapon", "rarity": "legendary",
-        "value_caps": 15000, "value_fizz": 1200, "nft_eligible": true,
-        "description": "The legendary axe of Grognak the Barbarian, escaped from a comic book and somehow real.",
-        "damage": 175, "weight": 8.0, "special_effect": "enemies_flee_on_critical",
-        "nft_metadata": { "collection": "Vault-77 Legendary Arsenal", "rarity_rank": 28 }
+        "id": "grognaks_axe",
+        "name": "Grognak's Axe",
+        "type": "weapon",
+        "weight": 1.5,
+        "capsValue": 1800,
+        "tradeable": true,
+        "description": "Legendary two-handed axe from the comics. Deals massive bleed damage."
       },
       {
-        "id": "prototype_gauss_pistol", "name": "Prototype Gauss Pistol", "type": "weapon", "rarity": "legendary",
-        "value_caps": 35000, "value_fizz": 2800, "nft_eligible": true,
-        "description": "Pre-war research prototype. Only three were ever built. One is in the Smithsonian. One is lost. This is the third.",
-        "damage": 110, "ammo_type": "ammo_2mm_ec", "weight": 3.8, "charge_speed": "instant",
-        "nft_metadata": { "collection": "Vault-77 Legendary Arsenal", "rarity_rank": 5 },
-        "progression_unlock": "quest_prototype_origins"
+        "id": "prototype_gauss_pistol",
+        "name": "Prototype Gauss Pistol",
+        "type": "weapon",
+        "weight": 1.5,
+        "capsValue": 2200,
+        "tradeable": true,
+        "description": "Pre-war experimental coilgun sidearm. One of a kind."
       },
       {
-        "id": "lucky_magnum", "name": "Lucky Magnum", "type": "weapon", "rarity": "legendary",
-        "value_caps": 20000, "value_fizz": 1600, "nft_eligible": true,
-        "description": "The Lucky .44 Magnum. Critical chance doubled. Found on every notable corpse in New Vegas.",
-        "damage": 62, "ammo_type": "ammo_44", "weight": 4.0, "crit_chance_multiplier": 2.0,
-        "timeline": "fallout_new_vegas",
-        "nft_metadata": { "collection": "Vault-77 Legendary Arsenal", "rarity_rank": 19 }
+        "id": "lucky_magnum",
+        "name": "Lucky Magnum",
+        "type": "weapon",
+        "weight": 1.5,
+        "capsValue": 1600,
+        "tradeable": true,
+        "description": "A legendary .44 with impossibly high critical hit odds."
       },
       {
-        "id": "overseer_long_coat_legendary", "name": "Overseer's Legendary Coat", "type": "armor", "rarity": "legendary",
-        "value_caps": 40000, "value_fizz": 3200, "nft_eligible": true,
-        "description": "The actual coat of a Vault-Tec Overseer who walked into the wasteland and never came back.",
-        "armor_rating": 80, "slot": "chest", "charisma_bonus": 3, "leadership_aura": true, "weight": 4.5,
-        "nft_metadata": { "collection": "Vault-77 Overseer Artifacts", "rarity_rank": 3 },
-        "progression_unlock": "quest_overseer_legacy"
+        "id": "overseers_legendary_coat",
+        "name": "Overseer's Legendary Coat",
+        "type": "armor",
+        "weight": 1.5,
+        "capsValue": 2000,
+        "tradeable": true,
+        "description": "Vault-Tec Overseer formal wear. Max ballistic and rad protection.",
+        "slot": "full",
+        "armorSet": null
       },
       {
-        "id": "vaultec_proto_fizz_chip", "name": "Proto-FIZZ Authentication Chip", "type": "quest_item", "rarity": "legendary",
-        "value_caps": 100000, "value_fizz": 8000, "nft_eligible": true,
-        "description": "A Vault-Tec pre-war master authentication token. Access to every Vault's resource reserve database.",
-        "quest_item": true, "quest_id": "qtl_boneyard_brotherhood",
-        "nft_metadata": { "collection": "Vault-77 Overseer Artifacts", "rarity_rank": 1 }
+        "id": "t51b_pa_head",
+        "name": "T-51b Power Armor Helmet",
+        "type": "armor",
+        "armorSet": "t51b_power_armor",
+        "slot": "head",
+        "weight": 0.4,
+        "capsValue": 500,
+        "tradeable": true,
+        "description": "Peak pre-war power armor helmet. Sealed rad filter."
       },
       {
-        "id": "t51b_power_armor_full", "name": "T-51b Power Armor (Full Set)", "type": "armor", "rarity": "legendary",
-        "value_caps": 60000, "value_fizz": 4800, "nft_eligible": true,
-        "description": "Complete T-51b power armor set, pristine condition. The peak of pre-war personal armor.",
-        "armor_rating": 140, "power_armor": true, "full_set": true, "weight": 92.0,
-        "nft_metadata": { "collection": "Vault-77 Legendary Arsenal", "rarity_rank": 8 }
+        "id": "t51b_pa_chest",
+        "name": "T-51b Power Armor Torso",
+        "type": "armor",
+        "armorSet": "t51b_power_armor",
+        "slot": "chest",
+        "weight": 0.4,
+        "capsValue": 500,
+        "tradeable": true,
+        "description": "T-51b torso. Enclave-grade ballistic ceramic plating."
       },
       {
-        "id": "alien_blaster", "name": "Alien Blaster", "type": "weapon", "rarity": "legendary",
-        "value_caps": 80000, "value_fizz": 6400, "nft_eligible": true,
-        "description": "Not of this earth. Literally. Disintegrates most organics on contact.",
-        "damage": 250, "ammo_type": "alien_power_cell", "weight": 2.0, "damage_type": "alien_energy",
-        "nft_metadata": { "collection": "Vault-77 Legendary Arsenal", "rarity_rank": 2 },
-        "progression_unlock": "quest_crash_site_roswell"
+        "id": "t51b_pa_arm_l",
+        "name": "T-51b Power Armor Left Arm",
+        "type": "armor",
+        "armorSet": "t51b_power_armor",
+        "slot": "arm_l",
+        "weight": 0.3,
+        "capsValue": 400,
+        "tradeable": true,
+        "description": "Left arm assembly. Still hums with servo power."
+      },
+      {
+        "id": "t51b_pa_arm_r",
+        "name": "T-51b Power Armor Right Arm",
+        "type": "armor",
+        "armorSet": "t51b_power_armor",
+        "slot": "arm_r",
+        "weight": 0.3,
+        "capsValue": 400,
+        "tradeable": true,
+        "description": "Right arm assembly. Gatling mount compatible."
+      },
+      {
+        "id": "t51b_pa_leg_l",
+        "name": "T-51b Power Armor Left Leg",
+        "type": "armor",
+        "armorSet": "t51b_power_armor",
+        "slot": "leg_l",
+        "weight": 0.3,
+        "capsValue": 400,
+        "tradeable": true,
+        "description": "Left leg assembly. Hydraulics mint condition."
+      },
+      {
+        "id": "t51b_pa_leg_r",
+        "name": "T-51b Power Armor Right Leg",
+        "type": "armor",
+        "armorSet": "t51b_power_armor",
+        "slot": "leg_r",
+        "weight": 0.3,
+        "capsValue": 400,
+        "tradeable": true,
+        "description": "Right leg assembly. Final piece of a legend."
+      },
+      {
+        "id": "alien_blaster",
+        "name": "Alien Blaster",
+        "type": "weapon",
+        "weight": 1.0,
+        "capsValue": 3500,
+        "tradeable": true,
+        "description": "Extraterrestrial sidearm firing alien power cells. Extremely rare."
+      },
+      {
+        "id": "proto_fizz_auth_chip",
+        "name": "Proto-FIZZ Authentication Chip",
+        "type": "quest_item",
+        "weight": 0.8,
+        "capsValue": 5000,
+        "tradeable": false,
+        "description": "Vault-Tec prototype authentication chip. Opens sealed FIZZ vaults."
+      },
+      {
+        "id": "legendary_caps_cache",
+        "name": "Legendary CAPS Cache",
+        "type": "currency",
+        "weight": 1.0,
+        "capsValue": 1000,
+        "tradeable": false,
+        "capsMin": 500,
+        "capsMax": 1500,
+        "onChain": true,
+        "description": "A legendary hoard of bottle caps. The find of a lifetime."
       }
     ],
     "nft_items": [
       {
-        "id": "fizz_genesis_token", "name": "FIZZ Genesis Token", "type": "nft_item", "rarity": "legendary",
-        "value_caps": 500000, "value_fizz": 50000, "nft_eligible": true,
-        "description": "One of 77 Genesis Tokens minted when FIZZ launched. Proof of original wasteland survival.",
-        "nft_metadata": {
-          "collection": "FIZZ Genesis Collection",
-          "total_supply": 77,
-          "rarity_rank": "1-77",
-          "blockchain": "solana",
-          "royalty_pct": 7
-        },
-        "drop_weight": 0.001
+        "id": "fizz_genesis_token",
+        "name": "FIZZ Genesis Token",
+        "type": "nft_item",
+        "weight": 0.8,
+        "capsValue": 0,
+        "onChain": true,
+        "mintable": true,
+        "edition": "legendary",
+        "tradeable": true,
+        "description": "One of the first FIZZ tokens ever minted. Legendary status on-chain."
       },
       {
-        "id": "vault77_overseer_badge", "name": "Vault 77 Overseer Badge", "type": "nft_item", "rarity": "epic",
-        "value_caps": 15000, "value_fizz": 1200, "nft_eligible": true,
-        "description": "Official badge of a Vault 77 Overseer. Grants administrative status in any surviving vault.",
-        "nft_metadata": {
-          "collection": "Vault-77 Overseer Artifacts",
-          "total_supply": 500,
-          "rarity_rank": "varies",
-          "blockchain": "solana"
-        },
-        "drop_weight": 0.005
+        "id": "vault77_overseer_badge",
+        "name": "Vault 77 Overseer Badge",
+        "type": "nft_item",
+        "weight": 2.0,
+        "capsValue": 0,
+        "onChain": true,
+        "mintable": true,
+        "edition": "rare",
+        "tradeable": true,
+        "description": "Official Vault 77 Overseer credential. Rare authority NFT."
       },
       {
-        "id": "wasteland_explorer_sigil", "name": "Wasteland Explorer Sigil", "type": "nft_item", "rarity": "rare",
-        "value_caps": 5000, "value_fizz": 400, "nft_eligible": true,
-        "description": "Awarded to players who have claimed 50 unique GPS locations. A mark of genuine wandering.",
-        "nft_metadata": {
-          "collection": "Vault-77 Explorer Achievements",
-          "total_supply": 2500,
-          "blockchain": "solana"
-        },
-        "progression_unlock": "achievement_50_pois",
-        "drop_weight": 0.02
+        "id": "wasteland_explorer_sigil",
+        "name": "Wasteland Explorer Sigil",
+        "type": "nft_item",
+        "weight": 2.0,
+        "capsValue": 0,
+        "onChain": true,
+        "mintable": true,
+        "edition": "rare",
+        "tradeable": true,
+        "description": "Sigil awarded to explorers who reach remote GPS POIs. Rare."
       },
       {
-        "id": "faction_war_veteran_token", "name": "Faction War Veteran Token", "type": "nft_item", "rarity": "rare",
-        "value_caps": 8000, "value_fizz": 640, "nft_eligible": true,
-        "description": "Proof of surviving 100 faction raid encounters. The wasteland remembers.",
-        "nft_metadata": {
-          "collection": "Vault-77 Combat Veterans",
-          "total_supply": 1000,
-          "blockchain": "solana"
-        },
-        "progression_unlock": "achievement_100_raids",
-        "drop_weight": 0.01
+        "id": "faction_war_veteran_token",
+        "name": "Faction War Veteran Token",
+        "type": "nft_item",
+        "weight": 1.5,
+        "capsValue": 0,
+        "onChain": true,
+        "mintable": true,
+        "edition": "epic",
+        "tradeable": true,
+        "description": "Commemorates surviving faction PvP battles. Epic tier NFT."
+      },
+      {
+        "id": "vaulttec_collectible_card",
+        "name": "Vault-Tec Collectible Card",
+        "type": "nft_item",
+        "weight": 2.5,
+        "capsValue": 50,
+        "onChain": true,
+        "mintable": true,
+        "edition": "uncommon",
+        "tradeable": true,
+        "description": "Vault-Tec promotional card NFT. Collectible, redeemable for CAPS."
+      },
+      {
+        "id": "wasteland_map_fragment",
+        "name": "Wasteland Map Fragment",
+        "type": "nft_item",
+        "weight": 2.0,
+        "capsValue": 75,
+        "onChain": true,
+        "mintable": true,
+        "edition": "rare",
+        "tradeable": true,
+        "craftable": true,
+        "description": "A fragment of a larger wasteland map NFT. Combine 4 to reveal a secret POI."
+      },
+      {
+        "id": "caps_chip_onchain",
+        "name": "CAPS Chip (On-Chain)",
+        "type": "nft_item",
+        "weight": 3.0,
+        "capsValue": 100,
+        "onChain": true,
+        "mintable": true,
+        "edition": "uncommon",
+        "tradeable": true,
+        "description": "On-chain token representing 100 CAPS. Redeemable at any settlement."
+      },
+      {
+        "id": "prototype_id_token",
+        "name": "Prototype ID Token",
+        "type": "nft_item",
+        "weight": 0.5,
+        "capsValue": 0,
+        "onChain": true,
+        "mintable": true,
+        "edition": "mythic",
+        "tradeable": true,
+        "unique": true,
+        "description": "Mythic-tier identity token. Only one exists per Vault in the game world."
       }
     ]
   },
   "faction_specific_loot": {
     "brotherhood_of_steel": {
-      "common_additions": ["fusion_cell", "laser_pistol"],
-      "rare_drops": ["brotherhood_holotape", "t45_power_armor_helm"],
-      "legendary_exclusive": ["t51b_power_armor_full"],
+      "common_additions": [
+        "fusion_cell",
+        "laser_pistol"
+      ],
+      "rare_drops": [
+        "brotherhood_holotape",
+        "t45_power_armor_helm"
+      ],
+      "legendary_exclusive": [
+        "t51b_power_armor_full"
+      ],
       "drop_note": "Brotherhood soldiers carry energy weapons and power armor components"
     },
     "ncr": {
-      "common_additions": ["ammo_556", "ammo_308"],
-      "rare_drops": ["ncr_ranger_armor", "combat_armor_chest"],
-      "legendary_exclusive": ["anti_materiel_rifle"],
+      "common_additions": [
+        "ammo_556",
+        "ammo_308"
+      ],
+      "rare_drops": [
+        "ncr_ranger_armor",
+        "combat_armor_chest"
+      ],
+      "legendary_exclusive": [
+        "anti_materiel_rifle"
+      ],
       "drop_note": "NCR soldiers are well-armed with conventional ballistic weapons"
     },
     "raiders": {
-      "common_additions": ["ammo_38", "pipe_pistol"],
-      "rare_drops": ["spiked_knuckles", "raider_armor_heavy"],
+      "common_additions": [
+        "ammo_38",
+        "pipe_pistol"
+      ],
+      "rare_drops": [
+        "spiked_knuckles",
+        "raider_armor_heavy"
+      ],
       "legendary_exclusive": [],
       "drop_note": "Raiders carry improvised weapons and scavenged armor"
     },
     "institute": {
-      "common_additions": ["fusion_cell"],
-      "rare_drops": ["synth_component", "institute_laser_pistol"],
-      "legendary_exclusive": ["prototype_gauss_pistol"],
+      "common_additions": [
+        "fusion_cell"
+      ],
+      "rare_drops": [
+        "synth_component",
+        "institute_laser_pistol"
+      ],
+      "legendary_exclusive": [
+        "prototype_gauss_pistol"
+      ],
       "drop_note": "Institute synths carry advanced technology rarely seen in the wasteland"
     },
     "railroad": {
-      "common_additions": ["stealth_boy"],
-      "rare_drops": ["ballistic_weave_schematic"],
-      "legendary_exclusive": ["railroad_armor_legendary"],
+      "common_additions": [
+        "stealth_boy"
+      ],
+      "rare_drops": [
+        "ballistic_weave_schematic"
+      ],
+      "legendary_exclusive": [
+        "railroad_armor_legendary"
+      ],
       "drop_note": "Railroad agents specialize in stealth and mobility"
     },
     "children_of_atom": {
-      "common_additions": ["glowing_one_gland", "irradiated_mushroom"],
-      "rare_drops": ["gamma_gun", "atom_glory_robe"],
+      "common_additions": [
+        "glowing_one_gland",
+        "irradiated_mushroom"
+      ],
+      "rare_drops": [
+        "gamma_gun",
+        "atom_glory_robe"
+      ],
       "legendary_exclusive": [],
       "drop_note": "Children of Atom carry radiation weapons and religious artifacts"
     },
     "gunners": {
-      "common_additions": ["ammo_556", "frag_grenade"],
-      "rare_drops": ["combat_armor_chest", "assault_rifle_military"],
-      "legendary_exclusive": ["gauss_rifle"],
+      "common_additions": [
+        "ammo_556",
+        "frag_grenade"
+      ],
+      "rare_drops": [
+        "combat_armor_chest",
+        "assault_rifle_military"
+      ],
+      "legendary_exclusive": [
+        "gauss_rifle"
+      ],
       "drop_note": "Gunners are professional mercenaries with military-grade equipment"
     },
     "enclave": {
-      "common_additions": ["plasma_cartridge", "advanced_power_cell"],
-      "rare_drops": ["enclave_power_armor_piece", "plasma_rifle"],
-      "legendary_exclusive": ["alien_blaster"],
+      "common_additions": [
+        "plasma_cartridge",
+        "advanced_power_cell"
+      ],
+      "rare_drops": [
+        "enclave_power_armor_piece",
+        "plasma_rifle"
+      ],
+      "legendary_exclusive": [
+        "alien_blaster"
+      ],
       "drop_note": "Enclave soldiers carry the most advanced technology available"
     },
     "super_mutants": {
-      "common_additions": ["ammo_308", "buffout"],
-      "rare_drops": ["minigun_damaged", "super_sledge_dented"],
-      "legendary_exclusive": ["fatman_launcher"],
+      "common_additions": [
+        "ammo_308",
+        "buffout"
+      ],
+      "rare_drops": [
+        "minigun_damaged",
+        "super_sledge_dented"
+      ],
+      "legendary_exclusive": [
+        "fatman_launcher"
+      ],
       "drop_note": "Super Mutants favor heavy weapons and rarely use armor"
     }
   },
   "timeline_specific_loot": {
     "fallout_1": {
-      "era_items": ["laser_pistol", "plasma_pistol_worn", "combat_armor_early"],
+      "era_items": [
+        "laser_pistol",
+        "plasma_pistol_worn",
+        "combat_armor_early"
+      ],
       "era_flavor": "First-generation post-war technology. Crude but functional.",
       "tech_level": "early"
     },
     "fallout_2": {
-      "era_items": ["advanced_power_armor_mkii", "turbo_plasma_rifle"],
+      "era_items": [
+        "advanced_power_armor_mkii",
+        "turbo_plasma_rifle"
+      ],
       "era_flavor": "Mature wasteland technology. Two generations of improvisation.",
       "tech_level": "mid"
     },
     "fallout_new_vegas": {
-      "era_items": ["anti_materiel_rifle", "lucky_magnum", "x_cell"],
+      "era_items": [
+        "anti_materiel_rifle",
+        "lucky_magnum",
+        "x_cell"
+      ],
       "era_flavor": "Mojave-specific technology. Diverse, well-maintained, NCR-influenced.",
       "tech_level": "mature"
     },
     "fallout_3": {
-      "era_items": ["combat_shotgun", "scoped_44_magnum", "deathclaw_gauntlet"],
+      "era_items": [
+        "combat_shotgun",
+        "scoped_44_magnum",
+        "deathclaw_gauntlet"
+      ],
       "era_flavor": "Capital Wasteland salvage. Rough but creative.",
       "tech_level": "mid"
     },
     "fallout_4": {
-      "era_items": ["plasma_rifle", "t45_power_armor_helm", "ballistic_weave_schematic"],
+      "era_items": [
+        "plasma_rifle",
+        "t45_power_armor_helm",
+        "ballistic_weave_schematic"
+      ],
       "era_flavor": "Commonwealth technology. Institute-influenced innovation.",
       "tech_level": "advanced"
     },
     "fallout_76": {
-      "era_items": ["handmade_rifle", "black_powder_pistol", "super_sledge_dented"],
+      "era_items": [
+        "handmade_rifle",
+        "black_powder_pistol",
+        "super_sledge_dented"
+      ],
       "era_flavor": "Early wasteland tech. The first survivors made do with very little.",
       "tech_level": "early"
     },
     "fallout_tactics": {
-      "era_items": ["mp5_smg_salvaged", "nightvision_goggles", "combat_armor_heavy"],
+      "era_items": [
+        "mp5_smg_salvaged",
+        "nightvision_goggles",
+        "combat_armor_heavy"
+      ],
       "era_flavor": "Midwest Brotherhood salvage. Military surplus emphasis.",
       "tech_level": "mid"
     }

--- a/public/exchange.html
+++ b/public/exchange.html
@@ -75,6 +75,15 @@
     <h1>SCAVENGER'S EXCHANGE</h1>
     <p style="text-align:center;">Post your trades • Buy from other wastelanders • Powered by Solana</p>
 
+    <!-- Workbench shortcut -->
+    <div style="text-align:center; margin:14px 0;">
+      <a href="/workbench" target="workbench_terminal"
+         style="display:inline-block; padding:10px 22px; background:#003300; color:#00ff41; border:1px solid #00ff41; font-family:'Press Start 2P',cursive; font-size:0.7em; text-decoration:none; cursor:pointer;"
+         onclick="var f='resizable=yes,scrollbars=yes,width=900,height=800,left='+Math.floor((screen.width-900)/2)+',top='+Math.floor((screen.height-800)/2); window.open('/workbench','workbench_terminal',f); return false;">
+        🔧 ARMOR WORKBENCH → Craft &amp; Assemble Gear Here
+      </a>
+    </div>
+
     <!-- Wallet status -->
     <div id="walletStatus" style="text-align:center; margin:20px 0;">
       <button id="connectWalletBtn">Connect Phantom Wallet</button>

--- a/public/index.html
+++ b/public/index.html
@@ -395,11 +395,20 @@
 
                     <div class="panel-divider"></div>
 
-                    <!-- NUKE FUSION CHAMBER -->
+                    <!-- NUKE PORTAL (BURN GEAR ONLY) -->
                     <div id="nukeSection">
-                      <div class="panel-header">⚛️ GEAR FUSION CHAMBER</div>
-                      <p style="font-size: 11px; opacity: 0.7; margin-bottom: 8px;">Combine NFT gear to create powerful fusion items. Requires connected wallet.</p>
-                      <button class="pipboy-button" id="openNukeTerminal">☢️ OPEN FUSION CHAMBER</button>
+                      <div class="panel-header">☢️ NUKE PORTAL</div>
+                      <p style="font-size: 11px; opacity: 0.7; margin-bottom: 8px;">Destroy gear permanently for CAPS / XP. No crafting here.</p>
+                      <button class="pipboy-button" id="openNukeTerminal">☢️ NUKE PORTAL — BURN GEAR</button>
+                    </div>
+
+                    <div class="panel-divider"></div>
+
+                    <!-- ARMOR WORKBENCH -->
+                    <div id="workbenchSection">
+                      <div class="panel-header">🔧 ARMOR WORKBENCH</div>
+                      <p style="font-size: 11px; opacity: 0.7; margin-bottom: 8px;">Assemble full armor sets from collected pieces. Craft consumables &amp; gear mods.</p>
+                      <button class="pipboy-button" id="openWorkbenchTerminal">🔧 OPEN WORKBENCH</button>
                     </div>
 
                     <div class="panel-divider"></div>
@@ -561,6 +570,8 @@
         const btn = document.getElementById("openOverseerTerminal");
         const nukeSection = document.getElementById("nukeSection");
         const nukeBtn = document.getElementById("openNukeTerminal");
+        const workbenchSection = document.getElementById("workbenchSection");
+        const workbenchBtn = document.getElementById("openWorkbenchTerminal");
         const bridgeSection = document.getElementById("bridgeSection");
         const bridgeBtn = document.getElementById("openBridgeTerminal");
 
@@ -622,6 +633,32 @@
           window.open("/nuke", "nuke_terminal", features);
         }
 
+        function openWorkbenchPopup() {
+          const screenW = window.innerWidth || screen.width;
+          const screenH = window.innerHeight || screen.height;
+
+          const width = Math.min(960, Math.max(480, Math.floor(screenW * 0.8)));
+          const height = Math.min(900, Math.max(600, Math.floor(screenH * 0.85)));
+
+          const left = Math.floor((screenW - width) / 2);
+          const top = Math.floor((screenH - height) / 2);
+
+          const features = [
+            "resizable=yes",
+            "scrollbars=yes",
+            "status=no",
+            "toolbar=no",
+            "menubar=no",
+            "location=no",
+            "width=" + width,
+            "height=" + height,
+            "left=" + left,
+            "top=" + top
+          ].join(",");
+
+          window.open("/workbench", "workbench_terminal", features);
+        }
+
         function openBridgePopup() {
           const screenW = window.innerWidth || screen.width;
           const screenH = window.innerHeight || screen.height;
@@ -659,10 +696,17 @@
           nukeBtn.addEventListener("click", function (e) {
             e.preventDefault();
             if (nukeBtn.disabled) {
-              alert('⚠️ NUKE SYSTEM LOCKED\n\nThe Gear Fusion Chamber is currently disabled.\nAdmin activation required.\n\nComing soon!');
+              alert('☢️ NUKE PORTAL LOCKED\n\nThe Nuke Portal — Burn Gear is currently disabled.\nAdmin activation required.\n\nComing soon!');
             } else {
               openNukePopup();
             }
+          });
+        }
+
+        if (workbenchBtn) {
+          workbenchBtn.addEventListener("click", function (e) {
+            e.preventDefault();
+            openWorkbenchPopup();
           });
         }
 

--- a/public/nuke.html
+++ b/public/nuke.html
@@ -29,13 +29,13 @@
 
         <!-- Header -->
         <div class="terminal-header">
-            ⚛️ GEAR FUSION CHAMBER
+            ☢️ NUKE PORTAL — BURN GEAR ONLY
         </div>
 
         <!-- Community project notice -->
         <!-- Not an official or commercial product; branding is fictional -->
         <div class="terminal-output terminal-system">
-            ⚠️ WARNING: PERMANENT DESTRUCTION • NO UNDO
+            ⚠️ WARNING: PERMANENT DESTRUCTION • NO UNDO • NO CRAFTING OR MERGING HERE
         </div>
 
         <!-- Gear list area -->

--- a/public/workbench.html
+++ b/public/workbench.html
@@ -1,0 +1,587 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>ARMOR WORKBENCH • ATOMIC FIZZ CAPS</title>
+
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'self';
+    script-src 'self' https://unpkg.com 'unsafe-inline';
+    connect-src 'self' https://atomicfizzcaps.xyz https://www.atomicfizzcaps.xyz https://api.atomicfizzcaps.xyz;
+    style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+    img-src 'self' data: https: blob:;
+    font-src 'self' https://fonts.gstatic.com data:;
+    object-src 'none';
+    frame-src 'self';
+    base-uri 'self';">
+
+  <link href="https://fonts.googleapis.com/css2?family=VT323&family=Press+Start+2P&display=swap" rel="stylesheet" />
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      background: #050f05;
+      color: #00ff41;
+      font-family: 'VT323', monospace;
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+    }
+
+    .wb-wrap {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 16px;
+    }
+
+    .wb-header {
+      text-align: center;
+      border: 2px solid #00ff41;
+      padding: 12px;
+      margin-bottom: 16px;
+      background: rgba(0, 255, 65, 0.06);
+      text-shadow: 0 0 8px #00ff41;
+    }
+    .wb-header h1 {
+      font-family: 'Press Start 2P', cursive;
+      font-size: 1.1em;
+      margin: 0 0 6px;
+      color: #00ff99;
+    }
+    .wb-header p {
+      font-size: 1.2em;
+      margin: 0;
+      opacity: 0.75;
+    }
+
+    /* Tabs */
+    .wb-tabs {
+      display: flex;
+      border-bottom: 2px solid #00ff41;
+      margin-bottom: 20px;
+    }
+    .wb-tab {
+      flex: 1;
+      background: transparent;
+      border: 1px solid #00ff41;
+      border-bottom: none;
+      color: #00ff41;
+      font-family: 'Press Start 2P', cursive;
+      font-size: 0.65em;
+      padding: 10px 6px;
+      cursor: pointer;
+      opacity: 0.55;
+      transition: all 0.15s;
+    }
+    .wb-tab:hover { opacity: 0.85; background: rgba(0,255,65,0.08); }
+    .wb-tab.active { opacity: 1; background: rgba(0,255,65,0.14); color: #00ff99; }
+
+    .wb-panel { display: none; }
+    .wb-panel.active { display: block; }
+
+    /* Armor Set Grid */
+    .set-list { display: flex; flex-direction: column; gap: 18px; }
+
+    .set-card {
+      border: 1px solid #00ff41;
+      background: rgba(0,255,65,0.05);
+      padding: 14px;
+    }
+    .set-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 10px;
+    }
+    .set-name {
+      font-family: 'Press Start 2P', cursive;
+      font-size: 0.75em;
+      color: #00ff99;
+    }
+    .set-tier {
+      font-size: 1em;
+      opacity: 0.6;
+      text-transform: uppercase;
+    }
+    .set-progress {
+      font-size: 1.1em;
+      color: #ffcc00;
+    }
+
+    .piece-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+    .piece-slot {
+      border: 1px solid #006619;
+      padding: 8px 6px;
+      text-align: center;
+      font-size: 1.1em;
+      background: rgba(0,0,0,0.4);
+      position: relative;
+    }
+    .piece-slot.have {
+      border-color: #00ff41;
+      background: rgba(0,255,65,0.12);
+    }
+    .piece-slot .slot-label {
+      font-size: 0.85em;
+      opacity: 0.7;
+      display: block;
+      margin-top: 2px;
+    }
+    .piece-slot .slot-icon { font-size: 1.5em; }
+
+    .assemble-btn {
+      display: block;
+      width: 100%;
+      padding: 10px;
+      background: #003300;
+      color: #00ff41;
+      border: 1px solid #00ff41;
+      font-family: 'Press Start 2P', cursive;
+      font-size: 0.65em;
+      cursor: not-allowed;
+      opacity: 0.4;
+      transition: all 0.15s;
+    }
+    .assemble-btn.ready {
+      background: #006619;
+      opacity: 1;
+      cursor: pointer;
+      box-shadow: 0 0 10px rgba(0,255,65,0.4);
+    }
+    .assemble-btn.ready:hover {
+      background: #00aa33;
+      color: #000;
+    }
+
+    .set-bonus {
+      font-size: 0.95em;
+      opacity: 0.65;
+      margin-top: 6px;
+    }
+    .set-bonus span { color: #a0e890; }
+
+    /* Crafting table */
+    .recipe-list { display: flex; flex-direction: column; gap: 14px; }
+    .recipe-card {
+      border: 1px solid #00ff41;
+      background: rgba(0,255,65,0.05);
+      padding: 12px;
+    }
+    .recipe-title {
+      font-family: 'Press Start 2P', cursive;
+      font-size: 0.7em;
+      color: #00ff99;
+      margin-bottom: 8px;
+    }
+    .recipe-materials { font-size: 1.05em; margin-bottom: 8px; }
+    .recipe-mat { display: inline-block; margin-right: 10px; }
+    .recipe-mat.have { color: #00ff41; }
+    .recipe-mat.need { color: #ff6633; }
+    .craft-btn {
+      padding: 8px 18px;
+      background: #003300;
+      color: #00ff41;
+      border: 1px solid #00ff41;
+      font-family: 'Press Start 2P', cursive;
+      font-size: 0.6em;
+      cursor: not-allowed;
+      opacity: 0.4;
+    }
+    .craft-btn.ready { opacity: 1; cursor: pointer; background: #006619; }
+    .craft-btn.ready:hover { background: #00aa33; color: #000; }
+
+    /* Status messages */
+    #wbStatus {
+      min-height: 24px;
+      text-align: center;
+      font-size: 1.2em;
+      margin-bottom: 12px;
+      color: #ffcc00;
+    }
+
+    /* Back button */
+    .back-bar {
+      text-align: right;
+      margin-top: 20px;
+    }
+    .back-btn {
+      background: transparent;
+      border: 1px solid #00ff41;
+      color: #00ff41;
+      font-family: 'Press Start 2P', cursive;
+      font-size: 0.6em;
+      padding: 8px 14px;
+      cursor: pointer;
+    }
+    .back-btn:hover { background: rgba(0,255,65,0.12); }
+
+    .divider { border: none; border-top: 1px solid rgba(0,255,65,0.25); margin: 14px 0; }
+  </style>
+</head>
+<body>
+
+<div class="wb-wrap">
+
+  <div class="wb-header">
+    <h1>🔧 ARMOR WORKBENCH</h1>
+    <p>Assemble full armor sets • Craft consumables &amp; gear</p>
+  </div>
+
+  <div id="wbStatus"></div>
+
+  <!-- Tabs -->
+  <div class="wb-tabs">
+    <button class="wb-tab active" data-tab="armor-workbench">🛡️ ARMOR WORKBENCH</button>
+    <button class="wb-tab" data-tab="crafting-table">⚙️ CRAFTING TABLE</button>
+  </div>
+
+  <!-- ARMOR WORKBENCH PANEL -->
+  <div class="wb-panel active" id="tab-armor-workbench">
+    <p style="font-size:1.1em; opacity:0.7; margin-bottom:14px;">
+      Collect all 6 pieces of an armor set to assemble the full set at the workbench.
+      Full sets grant bonus stats and higher trade value.
+    </p>
+    <div class="set-list" id="armorSetList">
+      <p style="opacity:0.5;">Loading armor sets...</p>
+    </div>
+  </div>
+
+  <!-- CRAFTING TABLE PANEL -->
+  <div class="wb-panel" id="tab-crafting-table">
+    <p style="font-size:1.1em; opacity:0.7; margin-bottom:14px;">
+      Craft consumables, ammo, and gear components using materials from your inventory.
+    </p>
+    <div class="recipe-list" id="craftingRecipeList">
+      <p style="opacity:0.5;">Loading recipes...</p>
+    </div>
+  </div>
+
+  <hr class="divider" />
+  <div class="back-bar">
+    <button class="back-btn" id="backBtn">← RETURN TO WRIST UI</button>
+  </div>
+
+</div>
+
+<script>
+(function () {
+  'use strict';
+
+  // ── Escape helper (XSS guard) ──────────────────────────────────────────────
+  function escHtml(str) {
+    const d = document.createElement('div');
+    d.textContent = String(str == null ? '' : str);
+    return d.innerHTML;
+  }
+
+  // ── Tab switching ───────────────────────────────────────────────────────────
+  document.querySelectorAll('.wb-tab').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      document.querySelectorAll('.wb-tab').forEach(function (b) { b.classList.remove('active'); });
+      document.querySelectorAll('.wb-panel').forEach(function (p) { p.classList.remove('active'); });
+      btn.classList.add('active');
+      const panel = document.getElementById('tab-' + btn.dataset.tab);
+      if (panel) panel.classList.add('active');
+    });
+  });
+
+  // ── Back button ─────────────────────────────────────────────────────────────
+  document.getElementById('backBtn').addEventListener('click', function () {
+    if (window.opener && !window.opener.closed) {
+      window.close();
+    } else {
+      window.location.href = '/';
+    }
+  });
+
+  // ── Status helper ────────────────────────────────────────────────────────────
+  const statusEl = document.getElementById('wbStatus');
+  function setStatus(msg, color) {
+    statusEl.style.color = color || '#ffcc00';
+    statusEl.textContent = msg;
+    if (msg) setTimeout(function () { statusEl.textContent = ''; }, 4000);
+  }
+
+  // ── Constants ────────────────────────────────────────────────────────────────
+  // ── Constants ────────────────────────────────────────────────────────────────
+  var UI_REFRESH_DELAY_MS = 1200; // Delay after success to let user read status before panel reloads
+
+  // ── Slot display config ──────────────────────────────────────────────────────
+  const SLOT_INFO = {
+    head:  { label: 'HEAD',      icon: '🪖' },
+    chest: { label: 'CHEST',     icon: '🦺' },
+    arm_l: { label: 'LEFT ARM',  icon: '💪' },
+    arm_r: { label: 'RIGHT ARM', icon: '💪' },
+    leg_l: { label: 'LEFT LEG',  icon: '🦵' },
+    leg_r: { label: 'RIGHT LEG', icon: '🦵' }
+  };
+
+  // ── Read player inventory from opener (Game.playerState) or localStorage ────
+  // Also syncs opener inventory to localStorage for persistence if the opener is later closed.
+  function getInventory() {
+    try {
+      if (window.opener && window.opener.Game && window.opener.Game.playerState) {
+        const inv = window.opener.Game.playerState.inventory;
+        const arr = Array.isArray(inv) ? inv : [];
+        // Sync to localStorage so the workbench stays consistent after opener closes
+        try { localStorage.setItem('playerInventory', JSON.stringify(arr)); } catch (e) {}
+        return arr;
+      }
+    } catch (e) { /* cross-origin guard */ }
+    try {
+      const raw = localStorage.getItem('playerInventory') || localStorage.getItem('vaultInventory');
+      if (raw) return JSON.parse(raw);
+    } catch (e) {}
+    return [];
+  }
+
+  function hasItem(inv, itemId) {
+    return inv.some(function (i) { return i && i.id === itemId; });
+  }
+
+  // ── Load armor sets and render ────────────────────────────────────────────────
+  async function loadArmorSets() {
+    let armorSets;
+    try {
+      const res = await fetch('/data/items/armor_sets.json');
+      armorSets = await res.json();
+    } catch (e) {
+      document.getElementById('armorSetList').innerHTML =
+        '<p style="color:#ff6633;">⚠️ Failed to load armor set data.</p>';
+      return;
+    }
+
+    const inv = getInventory();
+    const container = document.getElementById('armorSetList');
+    container.innerHTML = '';
+
+    Object.entries(armorSets).forEach(function ([setId, setDef]) {
+      const pieceIds = setDef.pieceIds;
+
+      // Validate that every slot in setDef.pieces has a corresponding pieceIds entry
+      const validatedPieces = setDef.pieces.filter(function (slot) {
+        if (!pieceIds[slot]) {
+          console.warn('[workbench] armor_sets.json: set "' + setId + '" piece "' + slot + '" missing from pieceIds');
+          return false;
+        }
+        return true;
+      });
+      const haveAll = validatedPieces.length === setDef.pieces.length &&
+        validatedPieces.every(function (slot) { return hasItem(inv, pieceIds[slot]); });
+      const haveCount = validatedPieces.filter(function (slot) {
+        return hasItem(inv, pieceIds[slot]);
+      }).length;
+
+      // Build piece grid HTML using validatedPieces
+      const piecesHtml = validatedPieces.map(function (slot) {
+        const have = hasItem(inv, pieceIds[slot]);
+        const info = SLOT_INFO[slot];
+        if (!info) console.warn('[workbench] SLOT_INFO missing entry for slot "' + slot + '"');
+        const display = info || { label: slot.toUpperCase(), icon: '🔲' };
+        return '<div class="piece-slot' + (have ? ' have' : '') + '">' +
+          '<span class="slot-icon">' + (have ? '✅' : display.icon) + '</span>' +
+          '<span class="slot-label">' + escHtml(display.label) + '</span>' +
+          '</div>';
+      }).join('');
+
+      const bonus = setDef.fullSetBonus;
+      const bonusHtml = '<div class="set-bonus">Full set bonus: ' +
+        '<span>+' + bonus.ballisticResist + ' ballistic</span> • ' +
+        '<span>+' + bonus.radResist + ' rad resist</span> • ' +
+        '<span>' + bonus.capsValue + ' CAPS value</span></div>';
+
+      const card = document.createElement('div');
+      card.className = 'set-card';
+      card.innerHTML =
+        '<div class="set-card-header">' +
+          '<span class="set-name">' + escHtml(setDef.name) + '</span>' +
+          '<span class="set-tier">' + escHtml(setDef.tier) + '</span>' +
+          '<span class="set-progress">' + haveCount + ' / 6 pieces</span>' +
+        '</div>' +
+        '<div class="piece-grid">' + piecesHtml + '</div>' +
+        bonusHtml +
+        '<button class="assemble-btn' + (haveAll ? ' ready' : '') + '" ' +
+          'data-recipe="' + escHtml(setDef.assembleRecipeId) + '" ' +
+          'data-set="' + escHtml(setId) + '"' +
+          (haveAll ? '' : ' disabled') + '>' +
+          (haveAll ? '🔧 ASSEMBLE FULL SET' : '🔒 COLLECT ALL 6 PIECES TO ASSEMBLE') +
+        '</button>';
+
+      container.appendChild(card);
+    });
+
+    // Wire up assemble buttons
+    container.querySelectorAll('.assemble-btn.ready').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        assembleSet(btn.dataset.recipe, btn.dataset.set, btn);
+      });
+    });
+  }
+
+  // ── Assemble a set (calls /api/crafting) ──────────────────────────────────────
+  async function assembleSet(recipeId, setId, btn) {
+    btn.disabled = true;
+    btn.textContent = '⚙️ ASSEMBLING...';
+    setStatus('Sending assembly request to workbench...', '#ffcc00');
+
+    try {
+      // Get auth token from opener if available
+      let authHeader = {};
+      try {
+        if (window.opener && window.opener.authToken) {
+          authHeader['Authorization'] = 'Bearer ' + window.opener.authToken;
+        }
+      } catch (e) {}
+
+      const baseUrl = (typeof window.API_BASE !== 'undefined' ? window.API_BASE : '') || '';
+      const res = await fetch(baseUrl + '/api/crafting', {
+        method: 'POST',
+        credentials: 'include',
+        headers: Object.assign({ 'Content-Type': 'application/json' }, authHeader),
+        body: JSON.stringify({ recipeId: recipeId })
+      });
+      const data = await res.json();
+
+      if (data.ok) {
+        setStatus('✅ ' + (data.message || 'Full set assembled! Check your inventory.'), '#00ff41');
+        // Refresh the panel after a short delay
+        setTimeout(loadArmorSets, UI_REFRESH_DELAY_MS);
+      } else {
+        setStatus('⚠️ ' + (data.error || 'Assembly failed. Try again.'), '#ff6633');
+        btn.disabled = false;
+        btn.textContent = '🔧 ASSEMBLE FULL SET';
+      }
+    } catch (e) {
+      setStatus('⚠️ Network error. Check your connection.', '#ff6633');
+      btn.disabled = false;
+      btn.textContent = '🔧 ASSEMBLE FULL SET';
+    }
+  }
+
+  // ── Load crafting recipes (non-armor_assembly) and render ────────────────────
+  async function loadCraftingRecipes() {
+    let recipes;
+    try {
+      const res = await fetch('/data/craftables/recipes.json');
+      recipes = await res.json();
+    } catch (e) {
+      document.getElementById('craftingRecipeList').innerHTML =
+        '<p style="color:#ff6633;">⚠️ Failed to load recipe data.</p>';
+      return;
+    }
+
+    const inv = getInventory();
+    const container = document.getElementById('craftingRecipeList');
+    container.innerHTML = '';
+
+    const displayRecipes = recipes.filter(function (r) { return r.type !== 'armor_assembly'; });
+
+    if (displayRecipes.length === 0) {
+      container.innerHTML = '<p style="opacity:0.5;">No crafting recipes available.</p>';
+      return;
+    }
+
+    displayRecipes.forEach(function (recipe) {
+      // Support both 'materials' (legacy recipes.json shape) and 'inputs' (armor_assembly shape)
+      const materials = recipe.materials || recipe.inputs || [];
+
+      const matsHtml = materials.map(function (mat) {
+        const itemId = mat.itemId || mat.id;
+        const qty = mat.qty || mat.amount || 1;
+        const have = inv.filter(function (i) { return i && i.id === itemId; })
+          .reduce(function (s, i) { return s + (i.quantity || i.amount || 1); }, 0);
+        const ok = have >= qty;
+        return '<span class="recipe-mat ' + (ok ? 'have' : 'need') + '">' +
+          escHtml(itemId) + ' ×' + qty +
+          (ok ? ' ✓' : ' (' + have + ' have)') +
+          '</span>';
+      }).join('');
+
+      const canCraft = materials.every(function (mat) {
+        const itemId = mat.itemId || mat.id;
+        const qty = mat.qty || mat.amount || 1;
+        const have = inv.filter(function (i) { return i && i.id === itemId; })
+          .reduce(function (s, i) { return s + (i.quantity || i.amount || 1); }, 0);
+        return have >= qty;
+      });
+
+      const output = recipe.output || {};
+      const card = document.createElement('div');
+      card.className = 'recipe-card';
+      card.innerHTML =
+        '<div class="recipe-title">' + escHtml(recipe.name) + '</div>' +
+        '<div class="recipe-materials">' + (matsHtml || '<em>No materials required</em>') + '</div>' +
+        '<div style="font-size:1em; opacity:0.65; margin-bottom:8px;">' +
+          '→ Produces: ' + escHtml(output.itemId || output.id || '?') +
+          (output.qty > 1 ? ' ×' + output.qty : '') +
+          (recipe.requiresLevel > 1 ? ' &nbsp;|&nbsp; Lvl ' + recipe.requiresLevel + '+' : '') +
+        '</div>' +
+        '<button class="craft-btn' + (canCraft ? ' ready' : '') + '" ' +
+          'data-recipe="' + escHtml(recipe.id) + '"' +
+          (canCraft ? '' : ' disabled') + '>' +
+          (canCraft ? '⚙️ CRAFT' : '🔒 MISSING MATERIALS') +
+        '</button>';
+
+      container.appendChild(card);
+    });
+
+    // Wire up craft buttons
+    container.querySelectorAll('.craft-btn.ready').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        craftItem(btn.dataset.recipe, btn);
+      });
+    });
+  }
+
+  // ── Craft an item (calls /api/crafting) ───────────────────────────────────────
+  async function craftItem(recipeId, btn) {
+    btn.disabled = true;
+    btn.textContent = '⚙️ CRAFTING...';
+    setStatus('Sending craft request...', '#ffcc00');
+
+    try {
+      let authHeader = {};
+      try {
+        if (window.opener && window.opener.authToken) {
+          authHeader['Authorization'] = 'Bearer ' + window.opener.authToken;
+        }
+      } catch (e) {}
+
+      const baseUrl = (typeof window.API_BASE !== 'undefined' ? window.API_BASE : '') || '';
+      const res = await fetch(baseUrl + '/api/crafting', {
+        method: 'POST',
+        credentials: 'include',
+        headers: Object.assign({ 'Content-Type': 'application/json' }, authHeader),
+        body: JSON.stringify({ recipeId: recipeId })
+      });
+      const data = await res.json();
+
+      if (data.ok) {
+        setStatus('✅ ' + (data.message || 'Item crafted! Check your inventory.'), '#00ff41');
+        setTimeout(loadCraftingRecipes, UI_REFRESH_DELAY_MS);
+      } else {
+        setStatus('⚠️ ' + (data.error || 'Craft failed. Try again.'), '#ff6633');
+        btn.disabled = false;
+        btn.textContent = '⚙️ CRAFT';
+      }
+    } catch (e) {
+      setStatus('⚠️ Network error.', '#ff6633');
+      btn.disabled = false;
+      btn.textContent = '⚙️ CRAFT';
+    }
+  }
+
+  // ── Init ────────────────────────────────────────────────────────────────────
+  loadArmorSets();
+  loadCraftingRecipes();
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
* Copilot/development status update (#220)

* Initial plan

* old commit  (#219)

* Initial plan

* docs: add STATUS.md project rundown and mainnet readiness assessment



* Initial plan

* Mainnet launch readiness: fix loot table RNG and Math.random() security violations

- Replace static loot table stub with weighted crypto-RNG (6 tiers, 54 items)
- Eliminate Math.random() from workers/mint_worker.js, mint_worker_stream.js, kms_stub.js
- Use rejection sampling for unbiased crypto index selection (CodeQL clean)
- Update docs/STATUS.md v1.0.2 with loot table fix status



* Initial plan

* fix: MCP broken tools, add leaderboard + cooldown status endpoints, upgrade agent registry



* Initial plan

* security: replace Math.random() with CSPRNG, add security tests and agent protocol

- Replace Math.random() with _secureRand() (crypto.getRandomValues) in:
  - public/js/modules/dragonbones-npc.js (3 calls fixed)
  - public/js/modules/npc-portraits.js (1 call fixed)
  - public/js/modules/struggle-quips.js (1 call fixed)
- Add tests/security.test.js: 32 static-analysis security checks covering auth middleware, GPS distance validation, rate limiting, CORS, IDOR prevention, Math.random() absence in critical paths, and Overseer XSS prevention
- Create .github/agents/agent-network.md: inter-agent coordination protocol, security rules, ownership matrix, and JSON event schema for agent comms
- Update package.json test script to run security.test.js

All 32 security tests pass. No Math.random() remains in game-critical code.

* security: address code review feedback

- Use const instead of var for buf in _secureRand() helpers (dragonbones-npc.js, npc-portraits.js, struggle-quips.js)
- Consolidate wallet IDOR regex in security.test.js to single pattern /(?:const|let|var)\s+wallet\s*=\s*req\.body\.wallet/ for maintainability

* fix: improve IDOR test regex to catch destructuring + add origin:true CORS check



* Initial plan

* feat: import game studio agents from agent-tools repo

- Add game-creative-director, game-designer, game-technical-director, gameplay-programmer, and cybersecurity-expert agent markdown files to .github/agents/ (sourced from github.com/Unwrenchable/agent-tools)
- Register all 7 game studio agents (+ game-producer + game-qa-lead) in .agentx/agents.json (total: 67 agents)
- Update agents-instructions.md registry table and routing table
- Update .agentx/README.md with game studio agent table and commands


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/52686bee-b600-4f4e-89b0-40b327c1f0b8

* Initial plan

* Add /start onboarding command to Overseer terminal


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/702a21dd-6029-4a0e-8bb6-1fe63927d47a

* Game Studio Pass: Fix 9 P0/P1 bugs from QA audit + review feedback


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/ba1895bc-b0a8-4a08-b0f2-a8f0a4bfed9e

* P2/P3 pass: 9 more bugs fixed — radio CSPRNG, battle death window, leaderboard privacy, onboarding tutorial, crafting server validation


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/2c0be4d1-0306-44cf-9f73-2ce23fcb8cba

* Lint sweep: 0 errors — fix preserve-caught-error, useless-escape, no-redeclare, no-case-declarations, no-useless-assignment, no-useless-catch; overhaul ESLint config with global ignores + browser globals


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/46f93c75-63da-4cb9-96e7-03960b79c55e

* Warning sweep pass 2: 527→106 warnings via ESLint globals + unused var prefixing across world/overseer/backend files


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/a2e9c627-ffee-4be9-a029-2a63050d69e1

* Warning sweep pass 3: 106→32 warnings, 0 errors — fix world engine refs, overseer vars, frontend unused params


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/a24bfdbe-6747-42b7-9765-75b304951694

* Initial plan

* fix: duplicate quest activation, wallet connect modal, NPC Bless, character creator instructions


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/4573d9ce-a6f3-4078-a93b-46b15ce957ae

* fix: address code review — mobile safe-area toast, grant_items string format


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/4573d9ce-a6f3-4078-a93b-46b15ce957ae

* Initial plan

* feat: rename Pip-Boy to Pocket-Boy across all user-facing content

Replaces all occurrences of the trademarked "Pip-Boy" name with "Pocket-Boy" — an original Fallout-flavored device name that avoids Bethesda IP issues. Covers string literals, NPC dialogs, encounter text, item/quest descriptions, audio PSAs, UI labels, CSS comments, and JS comments across 76 files.

Internal CSS class names (.pipboy-*), JS identifiers (activatePipboy, pipboyScreen), and filenames (pipboy.css, pipboy.js) are left unchanged as they are technical identifiers not visible to players.

All 32 security tests pass. Zero CodeQL alerts.


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/7253250b-0a9f-4a1d-8c4d-535463d2131e

* Initial plan

* fix: playtest deep-dive — fix all 20 bugs (4 critical, 4 high, 6 medium, 6 low)


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/dbe6be07-47ca-4731-923c-6a4f4ca841fe

* fix: address code review feedback — shared applyXpToProfile(), add rate-limiting to redeem-voucher, rename profileKey, fix test assertions


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/dbe6be07-47ca-4731-923c-6a4f4ca841fe

* Initial plan

* fix: 8 confirmed bugs from agent team audit (narrative crash, dialog gap, battle null guard, dungeon TOCTOU, wallet DoS, quest data)


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/8449fad8-e89d-4f42-941e-d4dc746ec834

* feat(narrative): add backstory fields and missing personality arrays to all NPC dialog files

- Add 'backstory' field (2-4 sentence lore paragraph) after 'description' in 27 dialog files: arnie, barney, bats, bless, commissar, courier, doc, dolores, dude, eli, erich, hannigan, jax, kenny, loxley, lucy, mara, mother, padre, phaltron, rex, roy8, siren, stilgar, warbucks, annie, harlan

- Add missing 'personality' arrays to: dialog_warbucks.json  → ['Ruthless', 'Transactional', 'Pragmatic'] dialog_hannigan.json  → ['Sharp', 'Mercenary', 'Unforgiving'] dialog_commissar.json → ['Philosophical', 'Conflicted', 'Methodical']
  dialog_annie.json     → ['Fiercely Independent', 'Observant', 'Stubborn']

- Full replacement: dialog_overseer.json Stub (personality-only) replaced with complete dialog tree: intro, 16 nodes, knowledge_nodes, emotional_nodes, wildcards, fallback Adds backstory, description, title, npc, portrait fields

- Full replacement: dialog_jax_body.json Stub replaced with ambient/reaction/ending entries plus all metadata

- Augmented: dialog_harlan.json Added npc, portrait, title, description, backstory to existing holotape-entry format; preserved all existing entries/mood/personality

All 38 public/data/narrative/*.json files pass JSON validation.

* feat(narrative): add npc metadata and backstory to echo, lena, rhea support characters


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/f9a13b4c-4864-4622-ad1a-c594433d56ca

* feat(narrative): add 6 NPC dialog files, 24 global quest files, and npc_registry.json

NPC Dialog files (public/data/narrative/):
- dialog_mira_vale.json — Freeside medic, side_nv_medrun quest hook
- dialog_nova_lane.json — Strip performer/informant, side_nv_novasecrets quest hook
- dialog_silas_reed.json — Strip strategist, quest_nv_convergence_signs quest hook
- dialog_signal_widow.json — Mojave Ridge listener, sq_signal_widow_frequency quest hook
- dialog_whisperer.json — Strip underground tunnels, sq_whisperer_pipes quest hook
- dialog_lena_cross.json — Strip runner who knew Jax, side_jax_lostsignal quest hook (NOTE: dialog_lena.json = Lena VOSS, dialog_lena_cross.json = Lena CROSS — different characters)

All dialog files follow canonical Jax Voss backstory: born 2261, taken 2277, Project J-77, consciousness distributed across Mojave relay towers, Echo/Vault 77 Overseer lore preserved.

Global Quest files (public/data/quest/):
24 worldwide quests for all 15 global NPCs (Madame Vex ×2, Tanaka-san, Ironbark, Dr. Beaumont, The Sphinx ×2, Carnival Ghost ×2, Navigator ×2, Iron Mother ×2, The Archivist ×2, Ghost Protocol, La Cocinera ×2, Lighthouse ×2, Vault Keeper Sigrid, The Coordinator ×2, El Gaucho). Each quest has GPS coordinates, 3-4 stages, and rewards.

NPC Registry (public/data/narrative/npc_registry.json): Cross-reference of 799 NPCs — maps canonical_name, dialog_file, npc_file, region, quest_ids. Covers all dialog files, all global NPCs, and named NPC files from public/data/npc/. Single source of truth for NPC identity going forward.

Validation: all 45 narrative and 84 quest JSON files parse cleanly.

* fix(narrative): clarify timeline in dialog_lena_cross; fix duplicate GPS coords in medicine_run

- dialog_lena_cross.json: added explicit year references (2273 for meeting, 2277 for disappearance)
- central_america_medicine_run.json: stage 3 delivery GPS offset ~800m from stage 2 raider checkpoint to prevent trigger conflicts (14.6412, -90.4981 vs raider checkpoint at 14.6349, -90.5069)

* fix: Jax Voss consistency + 6 NPC dialogs + 24 global quests + tighten walletVerify bounds


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/44994e63-919a-4064-a786-3e6275e8f06a

* Initial plan

* security: fix SEC-001/004/005/008/013 vulnerabilities

SEC-001: Overseer terminal XSS via game:event data
- Overseer.print() and addMessage() used div.innerHTML = String(text) without escaping, allowing injected HTML in poi names, inventory items, alert messages, and caps balance to execute as script
- Added _overseerEscapeHtml() helper; all terminal print paths now escape before insertion

SEC-004: fizz-fun /admin/launch IDOR (wallet from req.body)
- Endpoint had no authMiddleware; admin check read wallet from attacker- controlled req.body allowing anyone to test any wallet against ADMIN_WALLETS
- Added authMiddleware; wallet now sourced from verified session (req.player)

SEC-005: Player name has no length or character restriction
- POST /api/player/create accepted arbitrary strings including HTML/script tags with no length cap, enabling stored XSS via leaderboard/terminal display
- Name is now stripped of HTML-special chars and limited to 32 characters

SEC-008: fizz-fun endpoints have no rate limiting
- All seven fizz-fun routes had zero rate limiting, enabling enumeration, Solana RPC quota drain, and abuse of bonding-curve math endpoints
- Added fizzReadLimiter (60 req/min) and fizzWriteLimiter (10 req/min)

SEC-009: fizz-fun leaks raw error messages to clients
- Replaced res.status(500).json({ error: err.message }) with generic 'Internal server error' in all fizz-fun 500 handlers

SEC-013: /api/npc-context/:npcId/encounter unauthenticated, no rate limit
- Endpoint called xAI Grok / HF API with no auth and no per-route limiter; any unauthenticated caller could drain API token quota
- Added authMiddleware + encounterLimiter (5 req/min)
- Added npcContextLimiter (20 req/min) to static NPC context routes

.gitignore: added .env.testnet to prevent future accidental commits of environment-template files with default credentials

* security: address code review feedback on SEC-001/004/005/013 fixes

- overseer addMessage: simplify comment to match always-escape implementation
- player name: use allowlist regex [^a-zA-Z0-9\s\-_.] instead of denylist to block homograph/injection vectors and disallow emoji/unicode abuse
- npc-context encounterLimiter: use wallet-based key generator so shared IPs (NAT/corporate proxies) don't exhaust quota for all users behind the same IP
- fizz-fun admin/launch: log warning when ADMIN_WALLETS env var is empty to catch deployment misconfiguration; add fizzWriteLimiter to the route

* fix: pre-launch audit — 15 new security/bug fixes + 15 regression tests (63/63 pass)


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/a9c694cd-a253-4a61-8d27-7d7eb199c06d

* fix: apply 10 interrupted morning-session fixes (BUG-021–030) — 73/73 tests pass


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/ed35d6c2-1eb5-48fc-92ba-bb34882ab7aa

* fix: harden wallet connect flow for mainnet launch (5 surgical fixes)

Issue 1: Add uuid ^9.0.1 to root package.json dependencies

Issue 2: Refactor backend/routes/wallet.js
- Remove uuid dependency; use generateNonce/generateSessionId from lib/auth.js
- Replace manual redis.set/get/del wallet:nonce:* with storeNonce/getNonce/deleteNonce (unified auth:nonce: key namespace)
- Fix sig verification message: Buffer.from(nonce) -> Buffer.from('Atomic Fizz Caps login: '+nonce, 'utf8')
- Fix nonce response: { success, nonce } -> { ok: true, nonce }
- Fix verify response: { success, session } -> { ok: true, sessionId, wallet }
- Remove redundant inline require inside session route handler
- Remove unused direct redis import

Issue 2a: Export missing helpers from backend/lib/auth.js
- generateNonce, generateSessionId, storeNonce, getNonce, deleteNonce, storeSession, deleteSession now exported

Issue 3: Sync backend/package.json dep versions to root
- bs58: ^5.0.0 -> ^6.0.0
- helmet: ^7.1.0 -> ^8.0.0
- Add ioredis ^5.4.1 (used in backend/lib/keys.js)
- morgan and express-validator NOT added (not required in backend)

Issue 4: Fix AuthClient constructor signature
- constructor() -> constructor(options = {}) with explanatory comment

Issue 5: Prefix unused MAX_LEVEL import in backend/api/quests.js
- MAX_LEVEL -> _MAX_LEVEL (linter-safe unused import marker)

* fix: studio-wide playtest — wallet connect hardening & security fixes for mainnet (79/79 tests)


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/21caaeed-9d0c-49c3-940a-2f8346af7ac7

* Initial plan

* Pre-launch audit: fix 6 runtime undefined-var bugs + 5 gameplay/security issues

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/b28c0e34-9a0a-46a0-83c1-292e009ccb7d



* Round 2 audit: XSS fixes in wallet.js, Redis TTL wrapper, admin session metadata

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/820d91a8-5874-4af2-84c0-668721b9e4e6



* Initial plan

* fix: mobile UX + wallet connect overhaul for mainnet readiness

- donate.html: add missing viewport meta tag (was causing desktop-scale rendering on mobile)
- web3-wallet-adapter.js: Phantom mobile deeplink via universal-link (https://phantom.app/ul/browse/), pipboyConfirm() async Pip-Boy modal replaces blocking confirm() on mobile path
- mobile-swipe.js: new swipe gesture module for tab/panel navigation; MutationObserver wires full behaviour (not just touch listeners) on dynamically added nodes
- index.html: load mobile-swipe.js + data-swipe-tabs on .pipboy-tabs container
- pipboy.css: 100dvh + safe-area-inset overrides for main frame elements
- fo4-dialogue.css, live-radio.css, vats.css, dungeon.css: 100dvh + safe-area-inset blocks + 44px touch targets for mobile toolbar overlap
- wallet/wallet.css: prefers-reduced-motion + forced-colors accessibility
- All 79 security tests pass; 0 CodeQL alerts

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/c8e1bd96-01dd-4e1c-b89c-1a5815ece7ab



* fix: Exchange page wiring + security hardening

- backend/api/exchange.js: new Redis-backed exchange API GET /trades (public), POST /post-trade, POST /post-nft, POST /buy-trade, DELETE /cancel/:id (all write routes require authMiddleware) Falls back to scavenger.json seed data when Redis is empty HTML-encodes user text fields (preserve apostrophes, no strip) Validates NFT mint format (base58); seed-to-trade normalisation
- server.js: mount /api/exchange
- exchange.html: fix 4 broken /api/{trades,post-trade,post-nft,buy-trade} paths → /api/exchange/*; add escapeHtml() to all innerHTML; fix buy flow for pre-mainnet (no serializedTx); fix listNftBtn initial disabled state; tighten NFT image domain allow-list
- web3-wallet-adapter.js: _isMobileDevice() uses userAgentData.mobile first, then maxTouchPoints feature detection, then UA regex fallback; _buildPhantomDeeplink() uses only origin+pathname (not full href) to avoid forwarding user-controlled query params through deeplink
- mobile-swipe.js: MutationObserver batches mutations and defers processing via requestAnimationFrame (debounce) to avoid per-frame DOM overhead
- 79/79 security tests pass; 0 CodeQL alerts

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/3ae8b6e7-4fe1-4220-b2d9-f20bba80c72f



* Initial plan

* Fix mobile layout: wallet always top-right, map fills height, footer hidden on mobile

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/a817ab3a-2f76-48b9-a9bf-a14fbee3245d



* Wire all game systems, fix critical claiming/crafting bugs, close XSS exploits, improve offline play (#201)

* Fix mobile bottom cutoff: remove rogue dvh override on .pipboy-main, add safe-area-inset-bottom to GPS badge + map controls

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/de2711ec-6f94-488c-ad1f-c4400ea8b3a3



* fix: wire ITEMS tab, expand SW cache, clean dead-code comments

ITEMS tab (pipboy.js)
- Call Game.ui.renderInventory() every time the ITEMS panel opens so inventory is never stale on first visit to that tab.
- Add comment for STAT panel confirming HUD is kept live by main.js.

Service worker (sw.js)
- Bump CACHE_VERSION to v1.0.2-20260328 to invalidate stale caches.
- Expand PRECACHE_ASSETS from 10 items to 45+ covering boot/core scripts, key modules (worldmap, inventory-ui, quest-ui, narrative, battles, crafting, factions, vats, web3-wallet-adapter, live-radio-streaming), game engine scripts, world scripts, static JSON data (poi.json, fallout_pois.json, locations.json, items.json, factions.json), and all six radio playlist/station JSON files.
- Audio .mp3 tracks deliberately NOT pre-cached; the cache-first path caches them on first stream.

Dead-code comments (index.html)
- Collapse the three scattered legacy-module comments (npcEncounter.js, npc_signal_runner.js, fo4-dialogue.js, fo4-dialogue.css) into one clear DEAD CODE notice explaining all are superseded by narrative.js.
- Remove the dangling commented-out script/link tags.

.gitignore
- Add patterns for root-level developer scripts: /test-*.html, /test-*.js, /generate_*.js, /generate-*.js, /create-*.js, /verify-*.js, /merge-*.js, /integrate_*.js.



* feat: merge 20 Fallout POIs into poi.json (Gomorrah Casino, Vault 34, Nellis AFB, etc.)

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/988926f7-d3d2-467a-9a4b-d78d6e2ff8e4



* fix: playtest bugs - location claiming (all 642 POIs), redis.decr, crafting exploit, XSS, deeplink, tutorial button

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/8b4a45a6-083c-4a1c-b33c-b9079ca4d385



---------




* Replace standalone compass overlay with device-orientation–driven player marker arrow (#202)

* feat: wire battle system end-to-end, boost encounter rate, add offline indicator & admin debug tools (#203)

* Initial plan

* feat: battle tab, encounter wiring, encounter rate boost, offline indicator, admin debug tools

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/c201f7ec-c77a-4695-920c-bab78b693000



* fix: address code review — sw no-op listener, var→const, hp/damage fallbacks, localStorage key scan pattern

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/c201f7ec-c77a-4695-920c-bab78b693000



---------




* fix: eliminate player-marker compass jitter when stationary (#204)

* feat: add missing /api/ping, /api/version, /api/claim-survival routes

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/7da282f9-4349-49e2-871f-3fb500a44c49



* fix: use crypto.randomInt(-20, 21) for cleaner jitter range in claim-survival

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/7da282f9-4349-49e2-871f-3fb500a44c49



* fix: eliminate compass/player-marker jitter when stationary

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/7a512c03-d228-440e-8b9d-3605ba7af90c



* fix: clarify crypto.randomInt range comment in claim-survival

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/7a512c03-d228-440e-8b9d-3605ba7af90c



---------




* Pre-launch audit: fix 16 security + game bugs across all systems (#194)

* Initial plan

* Pre-launch audit: fix 16 security + game bugs, 58/58 tests green


Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/31559857-5e99-417d-b349-e25a43c55395

* Fix 5 PR review issues: decr() in redis, leaderboard chunking, quote style, tighter BUG-023 regex, client-authoritative item rewards

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/4e3861a5-2a0d-40ee-8380-a56b893dea1d



---------




* add hive-mind orchestrator agent (#205)




* unify agent network into cohesive game studio: trim agentx, fix instructions, add studio pipeline (#206)

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/adf32f6f-ab66-4770-a427-f306cb40a948




* Harden mainnet readiness: remove frontend key exposure, stabilize health/config under load, align playtest endpoints

* Fix Phantom signMessage base58 encoding in auth client

* Merge main → character-creator branch: auth bs58 fix + security/rate-limit patches (#207)

* Rework character creator UI to authentic Fallout 4 / Pip-Boy terminal aesthetic

- Add Oswald Bold Google Font import for headers/titles
- Apply Oswald to .cc-title, .cc-section-title, .cc-tab.active, .cc-confirm-btn, .cc-derived-title (letter-spacing 0.15em)
- Header: near-black terminal gradient + amber top border
- Vault seal: stronger dual-layer gold glow box-shadow
- Portrait container: phosphor border, amber corner bracket ::before, new .cc-scan-line-portrait and .cc-portrait-frame divs via JS
- Tabs: glass-tinted terminal style; active tab amber border-bottom
- Option items: dossier-file left-border accent, amber on hover
- Confirm button: dark green gradient, bright green border, Oswald, no animation
- SPECIAL stat rows: terminal display panels with thick left border accent
- Stat dots: true diamond shape (rotate 45deg, border-radius 0), amber fill
- Background/trait cards: dossier file left-border styling
- VAULT_BOY_SVGS: 7 unique full-colour Vault Boy bobblehead SVGs (50x60 viewBox) STR=flex, PER=binoculars, END=running, CHR=pointing, INT=glasses+book, AGI=star jump, LCK=thumbs up+stars
- Remove old vaultBoyIcon stub; replace with VAULT_BOY_SVGS lookup
- Replace emoji 📖 with cc-si-book-cover HTML (amber Vault-Tec book tile)



* fix: move Google Fonts to HTML link tags, add aria-hidden to star text elements

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/59865fe4-43a0-4d56-9c75-2530a75498e2



* Merge main into branch: bring in 5 fixes (auth bs58, frontend-config security, rate-limit skip, playtest corrections)

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/86516789-a2d0-4890-9889-29f2d85da874



* feat: remove COMBAT tab, wire battle panel to auto-trigger on encounters

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/e96f0f61-ff1e-4ad6-94ba-f9edc0d1fed1



---------




* Fix character creator mobile scroll and Phantom wallet external disconnect handling (#208)

* fix: Nova-7 mobile scroll block + Phantom wallet state sync (#209)

* Initial plan

* fix: Nova-7 mobile scroll + Phantom wallet event handling and silent reconnect

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/9b752634-1a6c-4f7f-819c-f1108e174b7a



* refactor: address code review — WeakSet for listener tracking, error.code 4001 check, storage warning

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/9b752634-1a6c-4f7f-819c-f1108e174b7a



---------




* Mainnet readiness: fix 3 critical Solana program bugs, 6 backend/frontend bugs, expand security tests 79→94 (#210)

* audit: fix BUG-040 loot-voucher crash, add /api/caps/redeem, normalize ok: responses (#211)

* Initial plan

* audit: fix BUG-040 nearbyPOI scope, add /api/caps/redeem, normalize ok: responses

BUG-040 (CRITICAL): loot-voucher.js - nearbyPOI declared with 'const' inside
  if-block was a ReferenceError when VOUCHER_LOCATIONS was non-empty. When GPS
  validation ran (the normal production path), the loot-voucher endpoint
  crashed on every single call, making loot collection completely broken.
  Fix: declare 'let nearbyPOI = null' in the outer scope before the if block.

FEAT: backend/api/caps.js - add POST /api/caps/redeem treasury redemption route.
  Players can now request redemption of in-game caps for real AFC tokens.
  The route: authenticates via authMiddleware, validates amount (100–10000),
  deducts caps atomically, records a redemption request in Redis for treasury
  processing, enforces a 24h per-wallet cooldown, and includes TOCTOU-safe
  concurrent-request locking. On-chain AFC token distribution remains manual
  (treasury has fixed supply; no minting is performed here).

RESPONSE SHAPE: normalize 'success:' → 'ok:' across exchange.js, scrap-nft.js
  and fuse.js. All API responses must use { ok: boolean } per project standard.
  Affected endpoints: exchange /post-trade, /post-nft, /buy-trade, /cancel/:id;
  scrap-nft POST /; fuse POST /.

No test regressions: all 94 security tests pass.



* audit: address code review — explicit null checks, named TTL constant

- Change 'if (!lockResult)' to 'if (lockResult === null)' in /api/caps/redeem for clarity and consistency with the NX cooldown check pattern above it.  The redis wrapper returns null (not false/undefined) when NX set fails; being explicit avoids confusion about what values are considered 'falsy'.
- Add comment explaining 'OK' vs null semantics of the redis wrapper's NX set.
- Extract magic number 30 * 24 * 3600 to REDEEM_REQUEST_TTL_SECONDS constant to match the style of the other timeout constants in the same file.



---------




* Add comprehensive Fallout universe quest/NPC/location content across all timelines (#214)

* Battery optimisation: Page Visibility API + GPS accuracy tuning (#215)

* Fix bs58 v6 CJS interop: `bs58.decode is not a function` crashes voucher key registration (#216)

* fix: crypto-side playtest — BUG-041–048 (NFT minting, loot tiers, CAPS economy, scrap lock) (#217)

* Initial plan

* fix: crypto-side playtest bugs BUG-041 through BUG-048

BUG-041 (High) - mint-item.js: Replace non-atomic GET+SET daily-limit check with atomic redis.incr() + expire() + decr-on-exceed to eliminate TOCTOU race where concurrent requests could bypass the mint daily cap.

BUG-042 (High) - Tiered loot CAPS economy non-functional:
- loot-voucher.js: Calculate CAPS reward from POI rarity (RARITY_CAPS map with env-configurable values per tier) and sign it into the voucher as voucher.caps so the redemption amount is server-authenticated.
- gps.js: Include voucher.caps in serializeVoucherMessage (backward- compatible: old vouchers without caps field still verify correctly).
- redeem-voucher.js: Use voucher.caps directly (covered by NaCl signature) instead of broken LOOT_ID_TO_CAPS comma-delimited parser.

BUG-043 (Medium) - loot-voucher.js: Expand randomInt lootId range from 1,000,000 to 2^48 to dramatically reduce birthday-paradox PDA seed collision probability for on-chain ClaimLoot.

BUG-044 (Medium) - redeem-voucher.js: Pre-call redis.key() in VOUCHER_USED_KEY so voucher replay-protection keys are stored at afw:afw:voucher:used:* (double-prefix, consistent with all other app keys) instead of afw:voucher:used:* (orphaned single-prefix).

BUG-046 (Low) - caps.js: Add capsBalanceLimiter (30 req/min) to GET /:wallet to prevent bulk wallet enumeration without authentication.

BUG-047 (Low) - player-state.js + dungeon.js: Add MAX_CAPS = 999_999_999 ceiling to awardCaps() and dungeon loot assignment to match backend limit and prevent Pip-Boy display overflow.

BUG-048 (Low) - scrap-nft.js: Use per-NFT lock key (wallet+nftMint) instead of per-wallet lock so concurrent scraps of different NFTs are no longer unnecessarily serialized with 15-second waits.

Add 11 regression tests (BUG-041..048) — total test count: 94 → 105.

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/a7f506f1-571b-46aa-90d1-a34a9d9856fb



* fix: clarify BUG-044 redis.key() double-prefix comment in redeem-voucher.js

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/a7f506f1-571b-46aa-90d1-a34a9d9856fb



---------




---------




---------




* old merge oops (#218) (#221)

* fix: Nova-7 mobile scroll block + Phantom wallet state sync (#209)

* Initial plan

* fix: Nova-7 mobile scroll + Phantom wallet event handling and silent reconnect

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/9b752634-1a6c-4f7f-819c-f1108e174b7a



* refactor: address code review — WeakSet for listener tracking, error.code 4001 check, storage warning

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/9b752634-1a6c-4f7f-819c-f1108e174b7a



---------




* Mainnet readiness: fix 3 critical Solana program bugs, 6 backend/frontend bugs, expand security tests 79→94 (#210)

* audit: fix BUG-040 loot-voucher crash, add /api/caps/redeem, normalize ok: responses (#211)

* Initial plan

* audit: fix BUG-040 nearbyPOI scope, add /api/caps/redeem, normalize ok: responses

BUG-040 (CRITICAL): loot-voucher.js - nearbyPOI declared with 'const' inside
  if-block was a ReferenceError when VOUCHER_LOCATIONS was non-empty. When GPS
  validation ran (the normal production path), the loot-voucher endpoint
  crashed on every single call, making loot collection completely broken.
  Fix: declare 'let nearbyPOI = null' in the outer scope before the if block.

FEAT: backend/api/caps.js - add POST /api/caps/redeem treasury redemption route.
  Players can now request redemption of in-game caps for real AFC tokens.
  The route: authenticates via authMiddleware, validates amount (100–10000),
  deducts caps atomically, records a redemption request in Redis for treasury
  processing, enforces a 24h per-wallet cooldown, and includes TOCTOU-safe
  concurrent-request locking. On-chain AFC token distribution remains manual
  (treasury has fixed supply; no minting is performed here).

RESPONSE SHAPE: normalize 'success:' → 'ok:' across exchange.js, scrap-nft.js
  and fuse.js. All API responses must use { ok: boolean } per project standard.
  Affected endpoints: exchange /post-trade, /post-nft, /buy-trade, /cancel/:id;
  scrap-nft POST /; fuse POST /.

No test regressions: all 94 security tests pass.



* audit: address code review — explicit null checks, named TTL constant

- Change 'if (!lockResult)' to 'if (lockResult === null)' in /api/caps/redeem for clarity and consistency with the NX cooldown check pattern above it.  The redis wrapper returns null (not false/undefined) when NX set fails; being explicit avoids confusion about what values are considered 'falsy'.
- Add comment explaining 'OK' vs null semantics of the redis wrapper's NX set.
- Extract magic number 30 * 24 * 3600 to REDEEM_REQUEST_TTL_SECONDS constant to match the style of the other timeout constants in the same file.



---------




* Add comprehensive Fallout universe quest/NPC/location content across all timelines (#214)

* Battery optimisation: Page Visibility API + GPS accuracy tuning (#215)

* Fix bs58 v6 CJS interop: `bs58.decode is not a function` crashes voucher key registration (#216)

* fix: crypto-side playtest — BUG-041–048 (NFT minting, loot tiers, CAPS economy, scrap lock) (#217)

* Initial plan

* fix: crypto-side playtest bugs BUG-041 through BUG-048

BUG-041 (High) - mint-item.js: Replace non-atomic GET+SET daily-limit check with atomic redis.incr() + expire() + decr-on-exceed to eliminate TOCTOU race where concurrent requests could bypass the mint daily cap.

BUG-042 (High) - Tiered loot CAPS economy non-functional:
- loot-voucher.js: Calculate CAPS reward from POI rarity (RARITY_CAPS map with env-configurable values per tier) and sign it into the voucher as voucher.caps so the redemption amount is server-authenticated.
- gps.js: Include voucher.caps in serializeVoucherMessage (backward- compatible: old vouchers without caps field still verify correctly).
- redeem-voucher.js: Use voucher.caps directly (covered by NaCl signature) instead of broken LOOT_ID_TO_CAPS comma-delimited parser.

BUG-043 (Medium) - loot-voucher.js: Expand randomInt lootId range from 1,000,000 to 2^48 to dramatically reduce birthday-paradox PDA seed collision probability for on-chain ClaimLoot.

BUG-044 (Medium) - redeem-voucher.js: Pre-call redis.key() in VOUCHER_USED_KEY so voucher replay-protection keys are stored at afw:afw:voucher:used:* (double-prefix, consistent with all other app keys) instead of afw:voucher:used:* (orphaned single-prefix).

BUG-046 (Low) - caps.js: Add capsBalanceLimiter (30 req/min) to GET /:wallet to prevent bulk wallet enumeration without authentication.

BUG-047 (Low) - player-state.js + dungeon.js: Add MAX_CAPS = 999_999_999 ceiling to awardCaps() and dungeon loot assignment to match backend limit and prevent Pip-Boy display overflow.

BUG-048 (Low) - scrap-nft.js: Use per-NFT lock key (wallet+nftMint) instead of per-wallet lock so concurrent scraps of different NFTs are no longer unnecessarily serialized with 15-second waits.

Add 11 regression tests (BUG-041..048) — total test count: 94 → 105.

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/a7f506f1-571b-46aa-90d1-a34a9d9856fb



* fix: clarify BUG-044 redis.key() double-prefix comment in redeem-voucher.js

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/a7f506f1-571b-46aa-90d1-a34a9d9856fb



---------




---------



* feat: Fallout-style armor piece collection system + Armor Workbench UI (#222)

* rework: overhaul loot_tables.json v2 - economy, balance, Fallout-authentic items

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/72ab58fc-0b55-46fd-ae51-bb3f98a1dea6



* feat: armor set piece system, workbench UI, nuke portal rebrand

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/4c9ffa80-d2ef-4d67-bb0e-b524ba49fad0



* fix: address code review feedback on workbench.html and index.html

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/4c9ffa80-d2ef-4d67-bb0e-b524ba49fad0



---------




* Add CodeQL workflow for code analysis

* Update CodeQL schedule cron timing

* fix: CodeQL Advanced workflow — Rust build-mode and Default Setup conflict (#223)

* fix: switch Rust CodeQL build-mode from none to autobuild

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/71ded65b-fc74-4072-a5c0-4153ae1398d6



* fix: revert Rust CodeQL build-mode from autobuild to none

Agent-Logs-Url: https://github.com/Unwrenchable/ATOMIC-FIZZ-CAPS-VAULT-77-WASTELAND-GPS/sessions/e0191f79-4b77-4f4a-85a3-2c3ec2436bb2



---------




---------